### PR TITLE
Migrate firefox-source-docs to Experimenter Docs

### DIFF
--- a/docs/desktop-frontend-testing.md
+++ b/docs/desktop-frontend-testing.md
@@ -1,0 +1,65 @@
+---
+id: desktop-frontend-testing
+title: Desktop Front-end testing
+slug: /desktop-frontend-testing
+---
+
+In order to make testing easier we created some helpers that can be accessed by including
+
+```js
+const { ExperimentFakes } = ChromeUtils.import(
+  "resource://testing-common/NimbusTestUtils.jsm",
+);
+```
+
+## Testing your feature integrating with Nimbus
+
+1. You need to create a recipe
+
+```js
+let recipe = ExperimentFakes.recipe("my-cool-experiment", {
+  branches: [
+    {
+      slug: "treatment-branch",
+      ratio: 1,
+      feature: {
+        featureId: "<YOUR FEATURE>",
+        // The feature is on
+        enabled: true,
+        // If you defined `variables` in the MANIFEST
+        // the `value` should match that schema
+        value: null,
+      },
+    },
+  ],
+  bucketConfig: {
+    start: 0,
+    // Ensure 100% enrollment
+    count: 10000,
+    total: 10000,
+    namespace: "my-mochitest",
+    randomizationUnit: "normandy_id",
+  },
+});
+```
+
+2. Now with the newly created recipe you want the test to enroll in the experiment
+
+```js
+let {
+  enrollmentPromise,
+  doExperimentCleanup,
+} = ExperimentFakes.enrollmentHelper(recipe);
+
+// Await for enrollment to complete
+
+await enrollmentPromise;
+
+// Now you can assume the feature is enabled so you can
+// test and that it's doing the right thing
+
+// Assert.ok(It works!)
+
+// Finishing up
+await doExperimentCleanup();
+```

--- a/docs/migration-guide-desktop-frontend.md
+++ b/docs/migration-guide-desktop-frontend.md
@@ -1,0 +1,86 @@
+---
+id: migration-guide-desktop-frontend
+title: Migration guide for Desktop Front-end
+slug: /migration-guide-desktop-frontend
+---
+
+This guide will help you integrate `ExperimentAPI.jsm` in your Desktop front-end code to run Nimbus experiments, while still being able to use preferences for default values and local development.
+
+In order to use `ExperimentAPI.jsm` your code must be able to import `jsm`s in the parent process or a privileged child process.
+
+## Register a new feature
+
+A feature is just some area of code instrumented for experiments – it can be as small as a single function or as complex as a whole about: page. You need to choose an identifier for your feature (e.g. "aboutnewtab").
+
+```javascript
+// In ExperimentAPI.jsm
+
+const MANIFEST = {
+  // Our feature name
+  aboutwelcome: {
+    description: "The about:welcome page",
+    // Control if the feature is on or off
+    enabledFallbackPref: "browser.aboutwelcome.enabled",
+    variables: {
+      // Additional (optional) values that we can control
+      // The name of these variables is up to you
+      skipFocus: {
+        type: "boolean",
+        fallbackPref: "browser.aboutwelcome.skipFocus",
+      },
+    },
+  },
+};
+
+// In firefox.js
+pref("browser.aboutwelcome.enable", true);
+pref("skipFocus", false);
+```
+
+> By setting fallback preferences for Nimbus features, you will be able to still run Normandy roll-outs and experiments while you are partially migrated. We do not recommend running Nimbus and Normandy experiments on the same feature/preference simultaneously.
+
+## How to use an Experiment Feature
+
+Import `ExperimentFeature` from `ExperimentAPI.jsm` and instantiate an instance
+
+```jsx
+XPCOMUtils.defineLazyGetter(this, "feature", () => {
+  const { ExperimentFeature } = ChromeUtils.import(
+    "resource://nimbus/ExperimentAPI.jsm",
+  );
+  // Here we use the same name we defined in the MANIFEST
+  return new ExperimentFeature("aboutwelcome");
+});
+```
+
+Access feature values:
+
+```jsx
+if (feature.isEnabled()) {
+  // Do something!
+  // This is controllbed by the `enabledFallbackPref` defined in the MANIFEST
+}
+
+// props: { skipFocus: boolean }
+const props = feature.getValue();
+renderSomeUI(props);
+```
+
+Defaults values inline:
+
+```jsx
+feature.isEnabled({ defaultValue: true });
+
+const { skipFocus } = feature.getValue() || {};
+```
+
+Listen to changes:
+
+```jsx
+// Listen to changes, including to fallback prefs.
+feature.on(() => {
+  updateUI(feature.getValue());
+});
+```
+
+For more examples and usecases please see the [SDK Docs](https://docs.google.com/document/d/1ev75pG0nAM1lz53WuPQkWqykUlZMmZRbx8wzvvn5DhU/edit#heading=h.hvm8985z4f8s).

--- a/sidebars.js
+++ b/sidebars.js
@@ -93,18 +93,8 @@ module.exports = {
       label: "Desktop Engineers",
       items: [
         "desktop-engineers-root",
-        {
-          type: "link",
-          label: "Front-End Migration Guide",
-          href:
-            "https://www.notion.so/Nimbus-Migration-Guide-for-Desktop-Front-End-Experiments-d36c21e505f84550aad1202897fc4ba3",
-        },
-        {
-          type: "link",
-          label: "SDK Docs (X-Man draft)",
-          href:
-            "https://docs.google.com/document/d/1ev75pG0nAM1lz53WuPQkWqykUlZMmZRbx8wzvvn5DhU/edit",
-        },
+        "migration-guide-desktop-frontend",
+        "desktop-frontend-testing",
       ],
     },
   ],


### PR DESCRIPTION
We want to migrate the [firefox-source-docs](https://searchfox.org/mozilla-central/source/toolkit/components/nimbus/docs) into Experimenter Docs and link here instead to make it easier to update and have better syntax highlighting, formatting etc.