### PR TITLE
Update with custom domain

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,8 +1,8 @@
 module.exports = {
   title: "Experimenter Docs",
   tagline: "Documentation hub for Experimenter",
-  url: "https://github.com/mozilla/experimenter-docs",
-  baseUrl: "/experimenter-docs/",
+  url: "https://experimenter.info",
+  baseUrl: "/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.ico",


### PR DESCRIPTION
This uses a new custom domain.

Note that if when we get a more appropriate `data.mozilla.org` domain in the future we will update it accordingly.