### PR TITLE
Fix broken cirrus image

### DIFF
--- a/docs/jetstream/operations.md
+++ b/docs/jetstream/operations.md
@@ -5,7 +5,7 @@ title: Jetstream Architecture and Operations
 
 **[Jetstream]** is part of the Cirrus ecosystem and depends on some external services.
 
-![Cirrus overview](https://github.com/mozilla/experimenter-docs/blob/main/static/img/jetstream/cirrus.png)
+![Cirrus overview](/img/jetstream/cirrus.png)
 *High-level overview of Cirrus*
 
 Jetstream is [scheduled to run in Airflow](https://github.com/mozilla/telemetry-airflow/blob/e5de501d8063cc366e9bb546135f3866136cb47d/dags/jetstream.py#L22) daily. The daily runs will analyze all experiments that are currently active or just ended the day before and write metrics, statistics and errors for each experiment to BigQuery. Active V1 experiments and V6 experiments (Nimbus experiments) are retrieved from the [Experimenter API](https://experimenter.services.mozilla.com/api/v1/experiments/).


### PR DESCRIPTION
## Description (optional)

Currently looks like this in Nightly:
![Jetstream_Architecture_and_Operations___Experimenter_Docs](https://user-images.githubusercontent.com/557895/116768144-572d6900-a9e9-11eb-999e-fb4eda31b226.png)
**Figure 1:** Cirrus link just shows alt text.

A bit more obvious in Chrome:
![Jetstream_Architecture_and_Operations___Experimenter_Docs](https://user-images.githubusercontent.com/557895/116768169-79bf8200-a9e9-11eb-88b6-14adaf23cbd8.png)
**Figure 2:** Broken image icon+alt text in Chrome.
