### PR TITLE
Add support for TOML syntax highlighting

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,7 +10,7 @@ module.exports = {
   projectName: "experimenter-docs",
   themeConfig: {
     prism: {
-      additionalLanguages: ["kotlin", "swift", "rust"]
+      additionalLanguages: ["kotlin", "swift", "rust", "toml"]
     },
     hideableSidebar: true,
     colorMode: {


### PR DESCRIPTION
## Description

Some of the [Jetstream docs](https://experimenter.info/jetstream/outcomes#defining-an-outcome) use TOML for configuration, but there doesn't seem to be pretty syntax highlighting.

Per https://docusaurus.io/docs/markdown-features/code-blocks#syntax-highlighting, it doesn't look like TOML is in the default [commonly used languages](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js), but it is a [Prism supported language](https://prismjs.com/#supported-languages).
