### PR TITLE
Remove step to explicitly ask for VPN access for Remote Settings.

### DIFF
--- a/docs/experiment-owners/access.md
+++ b/docs/experiment-owners/access.md
@@ -19,12 +19,11 @@ Assuming you have been vouched for by a Nimbus admininstrated + a Product Owner 
 #### Basic access
 * Read through [rules and responsibilities for L3 users](https://docs.google.com/document/d/1r8oI_Hxe5JQcOejqZcSziX1Aso20AFGBToTFu3BE5j8/edit#heading=h.6v62tolv8dnv). Please note that you will have access to making changes in production for all experiments, and you should decline if you don't feel sufficiently qualified to review an experiment
 * Follow the steps [setup VPN](https://mana.mozilla.org/wiki/display/SD/VPN)
-* [File a bug using this template](https://bugzilla.mozilla.org/enter_bug.cgi?product=Infrastructure%20%26%20Operations&component=Infrastructure%3A%20LDAP) to get access to remote settings staging and production via VPN
 * [File a bug using this template](https://bugzilla.mozilla.org/enter_bug.cgi?product=Cloud%20Services&component=Server%3A%20Remote%20Settings) to be added to either or both of the following collections: `nimbus-experiments-desktop` and/or `nimbus-experiments-mobile` for your LDAP to be added on staging and production.
 
 #### Testing Review Workflow on Staging
 * Connect to the VPN
-* Go to [Nimbus Staging](https://stage.experimenter.nonprod.dataops.mozgcp.net/nimbus/) (not Production!). Ask someone to create a dummy experiment and request review. 
+* Go to [Nimbus Staging](https://stage.experimenter.nonprod.dataops.mozgcp.net/nimbus/) (not Production!). Ask someone to create a dummy experiment and request review.
 * Click "Approve" on the dummy experiment, and then "Open Remote Settings":
 ![image](https://user-images.githubusercontent.com/1455535/144130977-149c2e65-4995-4040-a840-ea2baa0e3dc4.png)
 ![image](https://user-images.githubusercontent.com/1455535/144131295-8469c508-11d6-49e1-91d7-0bcf5d81efa6.png)
@@ -32,9 +31,8 @@ Assuming you have been vouched for by a Nimbus admininstrated + a Product Owner 
 ![image](https://user-images.githubusercontent.com/1455535/144131521-8516e6e1-7208-47dc-8183-ac1054542007.png)
 * **CHECK TO MAKE SURE THE SLUG OF THE DIFF MATCHES THE CHANGE YOU ARE APPROVING** This is important!!
 * Press approve if everything looks good. If anything looks wrong, Reject and alert nimbus core team in #ask-experiments
-* Congrats, you have tested the workflow. You are now ready to review real experiments on production! 
+* Congrats, you have tested the workflow. You are now ready to review real experiments on production!
 
 ### Reviews
 
 All changes to experiments and rollouts that impact production must be approved by a single L3 Nimbus reviewer, which you can request via the Nimbus console interface. You can find a list of [recommended reviewers here](https://mana.mozilla.org/wiki/display/FJT/Nimbus+Reviewers).
-


### PR DESCRIPTION
It is no longer required for users to separately ask for VPN access to the Remote Settings admin interface. We implicitly give that access to anyone who has permissions in the Remote Settings configuration, so simply asking for these permissions is all you need to do.