### PR TITLE
Update documentation to mention the new FeatureManifest.yaml for Desktop Nimbus

### DIFF
--- a/docs/desktop-feature-api-testing.mdx
+++ b/docs/desktop-feature-api-testing.mdx
@@ -75,7 +75,7 @@ Next this is how you would set up your feature to test integration with Desktop 
   await ExperimentAPI.ready();
   // The actual setup
   await ExperimentFakes.remoteDefaultsHelper({
-    // Reference your feature already defined in the FeatureManifest.js
+    // Reference your feature already defined in the FeatureManifest.yaml
     feature: NimbusFeatures.<YOUR FEATURE>,
     configuration: {
       // An identifier used in telemetry

--- a/docs/desktop-feature-api.mdx
+++ b/docs/desktop-feature-api.mdx
@@ -66,33 +66,29 @@ The Nimbus Feature API will return the correct configuration for a feature given
 
 ## Registering a new feature
 
-To register a new feature, you will need to choose an identifier and add it to the manifest in [FeatureManifest.js](https://searchfox.org/mozilla-central/source/toolkit/components/nimbus/FeatureManifest.js):
+To register a new feature, you will need to choose an identifier and add it to the manifest in [FeatureManifest.yaml](https://searchfox.org/mozilla-central/source/toolkit/components/nimbus/FeatureManifest.yaml):
+After adding the feature a build step is required to update the appropriate header file.
+
+```yaml
+# In FeatureManifest.yaml
+# Our feature name
+aboutwelcome:
+  description: The about:welcome page
+  # Include this if you need sychronous access / very early access at startup
+  # or if you are registering this to use for platform experiments.
+  isEarlyStartup: true
+  variables:
+    # Additional (optional) values that we can control
+    # The name of these variables is up to you
+    enabled:
+      type: boolean
+      fallbackPref: browser.aboutwelcome.enabled
+    skipFocus:
+      type: boolean
+
+```
 
 ```javascript
-// In FeatureManifest.js
-
-const MANIFEST = {
-  // Our feature name
-  aboutwelcome: {
-    description: "The about:welcome page",
-    // Include this if you need sychronous access / very early access at startup
-    // or if you are registering this to use for platform experiments.
-    isEarlyStartup: true,
-    variables: {
-      // Additional (optional) values that we can control
-      // The name of these variables is up to you
-      enabled: {
-        type: "boolean",
-        // Currently not supported for platform API
-        // See bug 1723755
-        fallbackPref: "browser.aboutwelcome.enabled",
-      },
-      skipFocus: {
-        type: "boolean",
-      },
-    },
-  },
-};
 
 // In firefox.js
 pref("browser.aboutwelcome.enabled", true);

--- a/docs/desktop-migration-guide.md
+++ b/docs/desktop-migration-guide.md
@@ -22,33 +22,27 @@ pref("browser.aboutmyself.bgcolor", "#FE8DAE");
 
 ## Step 1: Add a new feature to the manifest
 
-First, you will need to register a new feature in [FeatureManifest.js](https://searchfox.org/mozilla-central/source/toolkit/components/nimbus/FeatureManifest.js). In this case, we're creating one called `aboutmyself`.
+First, you will need to register a new feature in [FeatureManifest.yaml](https://searchfox.org/mozilla-central/source/toolkit/components/nimbus/FeatureManifest.yaml). In this case, we're creating one called `aboutmyself`.
+After adding the feature a build step is required to update the appropriate header file.
 
 Read more to find out if you want to send an [exposure event](/jetstream/jetstream/#enrollment-vs-exposure). This is optional but a decision must be recorded in the manifest.
 
 Each preference is registered as a `variable`:
 
-```js
-const FeatureManifest = {
-  aboutmyself: {
-    description: "A page that shows personal browsing stats.",
-    // Exposure is optional, in which case `hasExposure` would be false
-    // and `exposureDescription` would not be defined
-    hasExposure: true,
-    exposureDescription: "The exposure is the earliest moment that the user could be affected by the experimental treatment."
-    variables: {
-      enabled: {
-        type: "boolean",
-        fallbackPref: "browser.aboutmyself.enabled",
-      }
-      bgColor: {
-        type: "string",
-        fallbackPref: "browser.aboutmyself.bgcolor",
-      },
-    },
-  },
-};
-
+```yaml
+aboutmyself:
+  description: A page that shows personal browsing stats
+  # Exposure is optional, in which case `hasExposure` would be false
+  # and `exposureDescription` would not be defined
+  hasExposure: true
+  exposureDescription: The exposure is the earliest moment that the user could be affected by the experimental treatment
+  variables:
+    enabled:
+      type: boolean
+      fallbackPref: browser.aboutmyself.enabled
+    bgColor:
+      type: string
+      fallbackPref: browser.aboutmyself.bgcolor
 ```
 
 ## Step 2: Update your feature code


### PR DESCRIPTION
In [bug 1738937](https://bugzilla.mozilla.org/show_bug.cgi?id=1738937) we've switched the FeatureManifest declaration for Desktop to a yaml file. This updates the docs and examples.