### PR TITLE
Add 'Available Targeting' link to Messaging in sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -155,6 +155,11 @@ module.exports = {
           label: "Triggers & User Actions",
           href: "https://firefox-source-docs.mozilla.org/toolkit/components/messaging-system/docs/",
         },
+        {
+          type: "link",
+          label: "Available Targeting",
+          href: "https://firefox-source-docs.mozilla.org/browser/components/newtab/content-src/asrouter/docs/targeting-attributes.html",
+        }
       ],
     },
   ],


### PR DESCRIPTION
## Description 
- Add 'Available Targeting' link to sidebar under 'Messaging'

## Other information
<img width="301" alt="Screen Shot 2022-02-13 at 10 50 03 AM" src="https://user-images.githubusercontent.com/23217560/153761174-2ff6eef8-2176-4d79-aadd-afdb735b02e1.png">