### PR TITLE
enables miro autoplay

### DIFF
--- a/docs/getting-started/intro.md
+++ b/docs/getting-started/intro.md
@@ -14,7 +14,7 @@ Welcome to the [Experimenter](https://experimenter.services.mozilla.com/nimbus/)
 ## Experimentation Workflow 
 
 <div class="miro-container"> 
-<iframe class="responsive-iframe" src="https://miro.com/app/live-embed/uXjVOJ3IYRA=/?moveToViewport=-1075,981,1776,993" frameBorder="0" scrolling="no" allowFullScreen></iframe>
+<iframe class="responsive-iframe" src="https://miro.com/app/live-embed/uXjVOJ3IYRA=/?moveToViewport=-2130,380,5949,3025&embedAutoplay=true" frameBorder="0" scrolling="no"></iframe>
 </div>
 
 ## Find an existing experiment


### PR DESCRIPTION
## Description (optional)

Turns on autoplay for the Experimentation Workflow board in the getting started page. 

Previously, the site looked like this at first load:
![Screen Shot 2022-03-01 at 12 32 35 PM](https://user-images.githubusercontent.com/2738595/156461706-b01a5274-c370-45a3-8f90-0ea219d969e5.png)

And now, looks like this:

![Screen Shot 2022-03-02 at 2 36 59 PM](https://user-images.githubusercontent.com/2738595/156461724-dddb20f6-73b0-4312-8c5e-189fa45a127c.png)

