### PR TITLE
add experiment types table to capabilities page

### DIFF
--- a/docs/homepage/capabilities.md
+++ b/docs/homepage/capabilities.md
@@ -19,14 +19,22 @@ Nimbus is a full-featured experimentation platform that provides configuration, 
 - Monitoring and Analysis
 
 ## Experiment Types
-- A/A validation
-- A/B experiments
-- Holdback experiments
-- Messaging experiments
-- Feature Rollouts
-- Winning branch promotion
+|                          | Branches                                                                  | Control            | Co-existence / Avoidance                                                                                               | Enrollment                                                             | Analysis                                                                 | Good for?                                                                                          | Permanent Change                                                                   |
+|--------------------------|---------------------------------------------------------------------------|--------------------|------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------|--------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------|
+| Experiment               | A/B - equal sizes. Size fixed at launch - cannot grow.                    | Y                  | One per feature at a time.   Avoids other live experiments on a specific feature.  Keep as small as possible to learn. | Fixed timeframe. 7 day typically.  Analysis only AFTER enrollment ends | Automated for default metrics.  Can select outcomes or create new custom | Stat sig differences from control + absolute counts.                                               | No - all changes delivered through nimbus reverted.                                |
+| Message experiment       | Same AND each branch is given a messageID that the messaging system uses. | Same as experiment | Same as experiment AND message system throttles max # per time frame                                                   | Same as experiment                                                     | Same as experiment                                                       | Same as experiment                                                                                 | N Same as experiment                                                               |
+| Multi-feature experiment | Same as experiment                                                        | Same as experiment | Avoids other live experiment with EITHER FEATURE - **restricted audience                                               | Same as experiment                                                     | Same as experiment                                                       | Same as experiment                                                                                 | N Same as experiment                                                               |
+| Holdback Experiment      | Go right to end stage of rollout - 90% treatment                          | Y - 10%            | Same as experiment AND no other feature can be tested in this feature for the duration.                                | Same as experiment                                                     | Same as experiment                                                       | Decision made to deploy quickly - but want data.  A brief step before shipping as default in tree. | No - all changes delivered through nimbus reverted.  Fast follow shipping in tree. |
 
-## Multiple langauage Client integrations
+
+## Feature Delivery 
+|                                            | Branches                          | Control            | Co-existence / Avoidance                                                                                                                      | Enrollment                                                       | Analysis                                                                                     | Good for?                                                                                                                                          | Permanent Change                                                                                          |
+|--------------------------------------------|-----------------------------------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|----------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| Rollout Today                              | Size increases 5%, 25%, 50%, 100% | N                  | Unrestricted co-existence Does not avoid other rollouts or experiments.                                                                       | N/A                                                              | None - teams can make and monitor their own dashboards - but no “stat sig analysis” offered. | Risk mitigation for explosive failures (looking for crash, bugs, media issues)                                                                     | Yes.  Changes do not revert on targeted versions.   Teams ship as default in tree in the release at 100%. |
+| Branch Promotion                           | 1 - 100%                          | N                  | On an experiment with a winning branch - you can select “promote to rollout” which clones the ticket with the winning configuration filled in | N                                                                | N                                                                                            | Get winning branch to users quicker than trains                                                                                                    | Same as Rollout Today                                                                                     |
+| Do No Harm Monitoring Platform  Experiment | Same as experiment                | Same as experiment | Same as experiment.                                                                                                                           | No fixed timeframe means there is no automatic analysis trigger. | Not automated.  Requires OpMon configured or team using their own custom dashboards.         | Code changing/fixes landing during. Risk mitigation for quick major breaking stability / perf changes.   Looking at adding search metrics as well. | N Same as experiment                                                                                      |
+
+## Multiple language Client integrations
 - Android (Kotlin)
 - iOS (Swift)
 - Firefox Desktop Frontend (JS)
@@ -42,11 +50,11 @@ Nimbus is a full-featured experimentation platform that provides configuration, 
   - Frontend via JS SDK
   - Platform
   - Windows installer
-- Firefox Mobile via nimbus Rust Component
+- Firefox Mobile via Nimbus-SDK Rust Component
   - Fenix
   - Firefox iOS
   - Focus Andriod
-  -Focus iOS
+  - Focus iOS
 
 ## Requesting feature support
 If you aren't sure we have what you need, pop into #ask-experimenter with your questions or [file an issue](https://mozilla-hub.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10203&issuetype=10097) 

--- a/docs/homepage/intro.md
+++ b/docs/homepage/intro.md
@@ -16,13 +16,13 @@ Welcome to the [Experimenter](https://experimenter.services.mozilla.com/nimbus/)
 
 ## What is covered here?
 
-These documents are specific to the Mozilla experimentation program know as **Nimbus**.  Nimbus experimentation and support is currently available for our Firefox Desktop and Mobile browser applications.  
+These documents are specific to the Mozilla experimentation program known as **Nimbus**.  Nimbus experimentation and support is currently available for our Firefox Desktop and Mobile browser applications.  
 
 Our platform code is all open-source however, we do not offer support or services to 3rd party consumers. Some documentation links may only be available to Mozilla employees and NDA contributors.
 
 ## What other tools exist
 
-The following projects have bespoke tools for experimentation.  These are not included as part of this documentation with the exception of a migration guide from Normandy to Nimbus for engineers.
+The following projects have bespoke tools for experimentation.  These are not included as part of this documentation with the exception of a [migration guide from Normandy to Nimbus](desktop-migration-guide) for engineers.
 
 * Firefox Desktop (legacy experimentation): [Normandy](https://wiki.mozilla.org/Firefox/Normandy/PreferenceRollout)
 * Mozilla Websites (a/b experiments): [Bedrock](https://github.com/mozilla/bedrock)


### PR DESCRIPTION
## Description (optional)

- Adds the table of experiment and delivery  types to the Welcome section. 
- Cleans up a few typos

## Issue that this pull request resolves (optional)

n/a

