### PR TITLE
Adds number_of_app_launches atrribute custom attribute

### DIFF
--- a/docs/messaging/gleanplumb.mdx
+++ b/docs/messaging/gleanplumb.mdx
@@ -739,6 +739,7 @@ Attribute | Type | Description
 ----------|------|------------
 `is_default_browser_string`                 | string   | Should change to boolean on fixing [`==`][bool-equ] and [`!`][bool-not] |
 `date_string`                               | string   | In YYYY-MM-DD format                                                    |
+`number_of_app_launches`                    | int      | Indicates how many times the app has been launched.                     |
 
 It is possible this table is out of date. The definitive source of truth for this in [the code][fenix-attributes-eng] itself.
 


### PR DESCRIPTION
The number_of_app_launches custom attribute indicates how many times the app has been launched.
Related to https://github.com/mozilla-mobile/fenix/pull/25705
