### PR TITLE
fix #282: update broken link

### DIFF
--- a/docs/getting-started/for-engineers.md
+++ b/docs/getting-started/for-engineers.md
@@ -11,4 +11,4 @@ Engineers are typically tasked with implementing an experiment on a new surface 
 * Review the experiment design document.
 * Determine if you need to implement any additional telemetry collection
 * Check if you need to implement a custom audience
-* Confirm the name of the feature and follow the guide to [adding a new feature to the manifest](http://localhost:3000/feature-definition#to-define-your-feature-in-the-feature-manifest-file)
+* Confirm the name of the feature and follow the guide to [adding a new feature to the manifest](https://experimenter.info/feature-definition#to-define-your-feature-in-the-feature-manifest-file)


### PR DESCRIPTION
Because

* We accidentally had a link pointing to local dev instead of prod

This commit

* Updates to point to prod