### PR TITLE
Remove pref override from desktop client JS API documentation

### DIFF
--- a/docs/getting-started/desktop-feature-api.mdx
+++ b/docs/getting-started/desktop-feature-api.mdx
@@ -61,7 +61,7 @@ The Nimbus Feature API will return the correct configuration for a feature given
 
 1. **Experiment value**: First, we check if a Nimbus experiment is activated that changes the feature.
 1. **Remotely-configured value**: If no experiment is set, we check if there is a remotely-defined value. This is a mechanism that allows us to roll-out changes quickly between releases.
-1. **Local default**: Finally, we will return the _default branch_ of preferences in the manifest, if they are defined in [firefox.js](https://searchfox.org/mozilla-central/source/browser/app/profile/firefox.js).
+1. **Local default**: Finally, we will return the current value of preferences in the manifest, if they are defined in [firefox.js](https://searchfox.org/mozilla-central/source/browser/app/profile/firefox.js).
 
 ## Registering a new feature
 

--- a/docs/getting-started/desktop-feature-api.mdx
+++ b/docs/getting-started/desktop-feature-api.mdx
@@ -59,10 +59,9 @@ This section is relevant only for the JS API.
 
 The Nimbus Feature API will return the correct configuration for a feature given a few different inputs **in this order**:
 
-1. **End-user-setting**: If the _user branch_ of any preferences in the manifest are set, this will override experiment values or defaults. We believe this is important to respect user choice.
-2. **Experiment value**: Next, we check if a Nimbus experiment is activated that changes the feature.
-3. **Remotely-configured value**: If no experiment is set, we check if there is a remotely-defined value. This is a mechanism that allows us to roll-out changes quickly between releases.
-4. **Local default**: Finally, we will return the _default branch_ of preferences in the manifest, if they are defined in [firefox.js](https://searchfox.org/mozilla-central/source/browser/app/profile/firefox.js).
+1. **Experiment value**: First, we check if a Nimbus experiment is activated that changes the feature.
+1. **Remotely-configured value**: If no experiment is set, we check if there is a remotely-defined value. This is a mechanism that allows us to roll-out changes quickly between releases.
+1. **Local default**: Finally, we will return the _default branch_ of preferences in the manifest, if they are defined in [firefox.js](https://searchfox.org/mozilla-central/source/browser/app/profile/firefox.js).
 
 ## Registering a new feature
 


### PR DESCRIPTION
We recently removed the user branch pref override behaviour from the fallback pref, and so we need to update the documentation accordingly.
