### PR TITLE
fixes #303 docs(nimbus): Add local enrollment/unenrollment docs

### DIFF
--- a/docs/local-enrollment.md
+++ b/docs/local-enrollment.md
@@ -1,0 +1,34 @@
+# Local configuration for natural enrollments
+
+## Desktop
+Preferences to set in Firefox
+- `nimbus.debug`: `True`
+- `app.normandy.run_interval_seconds`: 30
+- `services.settings.server`: `http://localhost:8888/v1`
+
+Note: You can also use the [remote-settings-devtool](https://github.com/mozilla-extensions/remote-settings-devtools) addon to control some of these but the “app.normandy.run_interval_seconds” preference must still be set.
+
+## Instructions for Nimbus
+1. Set the above preferences within Firefox
+2. Create a desktop experiment with the following settings
+    - A desktop feature
+    - No advanced targeting 
+    - All Locales
+    - All Regions
+    - `Percent of clients`: 100%
+    - `Expected Number of Clients`: 1 (or any number above 0)
+3. Request Launch and Approve the experiment in Remote Settings
+4. Open the Browser Console to view the logs from “RSLoader” (`RemoteSettingsExperimentLoader.Jsm`)
+
+There should be log outputs of the RSLoader reading from remote settings and showing the JEXL evaluations being attempted. Eventually the experiment you created should be loaded and evaluated. If you are enrolled into a study with the same feature, the new experiment will not be allowed to enroll.
+ 5. Check `about:telemetry` for an event that looks like this
+- Enrollment
+    ```
+    normandy  enroll    nimbus_experiment <name-of-experiment>
+- Unenrollment
+    ```
+    normandy  unenroll  nimbus_experiment <name-of-experiment>
+    ```
+## Mobile
+
+Coming soon!

--- a/sidebars.js
+++ b/sidebars.js
@@ -189,6 +189,7 @@ module.exports = {
       label: "Additional Links",
       items: [
         "integration-tests",
+        "local-enrollment",
         {
           type: "link",
           label: "Experimenter GH Repo",


### PR DESCRIPTION
## Description (optional)

- This adds docs on how to enroll your local client into a localhost version of Nimbus.

Closes: mozilla/experimenter-docs#303

