### PR TITLE
Fixes #314: Link pre-existing rollouts FAQ in page tree

### DIFF
--- a/docs/deep-dives/experimenter/rollouts.mdx
+++ b/docs/deep-dives/experimenter/rollouts.mdx
@@ -1,11 +1,8 @@
 ---
-id: rollouts
+id: rollouts-deep-dive
 title: Rollouts
-slug: /rollouts
+slug: rollouts
 ---
-
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 # Rollouts
 

--- a/docs/workflow/rollouts-faq.md
+++ b/docs/workflow/rollouts-faq.md
@@ -1,8 +1,12 @@
 ---
-id: rollouts
-title: Rollouts
-slug: /rollouts
+id: rollouts-faq
+title: Rollouts FAQ
+slug: /rollouts-faq
 ---
+:::tip
+Want more info on rollouts?
+Take a look at our [deep dive](deep-dives/experimenter/rollouts), or reach out in [`#ask-experimenter`](https://mozilla.slack.com/archives/CF94YGE03) on Slack. 
+:::
 
 If you want to set configurations for a feature remotely _for non-experiment users_, you can do so with a **Rollout**.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -63,7 +63,13 @@ module.exports = {
     {
       "Experimentation Workflow": [
             "workflow/overview",
-            "workflow/designing",
+            {
+              "type": "category",
+              "label": "Designing",
+              "items": [
+                "workflow/rollouts-faq",
+              ]
+            },
             {
               "type": "category",
               "label": "Implementing",


### PR DESCRIPTION
## Description 

Because...
* There was a pre-existing `rollouts.md` that was lost in the documentation reorg
* The rollouts page added in #300 was using the same id (`/rollouts`)

This commit...
* Puts the pre-existing doc back in the `/workflow` folder
* Renames old one to `rollouts-faq`
* Renames new one to `rollouts-deep-dive`
* Adds a link at the top to the rollouts deep dive page

## Issue that this pull request resolves

Closes: #314 

<img width="320" alt="image" src="https://user-images.githubusercontent.com/43795363/194729118-47aa07b4-e4d7-4fe1-8d6c-1d233b91b440.png">

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/43795363/194729125-eb6b4bc0-3ee8-4086-810a-96a485483ca4.png">
