### PR TITLE
Update feature-definition.md to include links to manifest files

### DIFF
--- a/docs/workflow/feature-definition.md
+++ b/docs/workflow/feature-definition.md
@@ -14,5 +14,9 @@ In the experimentation ecosystem, experiment surfaces are described as features.
 Features are defined in a Feature Manifest file for the application, and the client code uses the Nimbus SDK to access variables associated with those features.
 
 ## To define your feature in the feature manifest file
-* Desktop
+First, look at what is already defined in the manifest file:
+* [Desktop](https://searchfox.org/mozilla-central/source/toolkit/components/nimbus/FeatureManifest.yaml)
 * Mobile
+    * [Fenix/Android](https://github.com/mozilla-mobile/fenix/blob/main/nimbus.fml.yaml)
+    * [Firefox iOS](https://github.com/mozilla-mobile/firefox-ios/blob/main/nimbus.fml.yaml)
+    * [Focus iOS](https://github.com/mozilla-mobile/focus-ios/blob/main/nimbus.fml.yaml)

--- a/docs/workflow/feature-definition.md
+++ b/docs/workflow/feature-definition.md
@@ -20,3 +20,4 @@ First, look at what is already defined in the manifest file:
     * [Fenix/Android](https://github.com/mozilla-mobile/fenix/blob/main/nimbus.fml.yaml)
     * [Firefox iOS](https://github.com/mozilla-mobile/firefox-ios/blob/main/nimbus.fml.yaml)
     * [Focus iOS](https://github.com/mozilla-mobile/focus-ios/blob/main/nimbus.fml.yaml)
+


### PR DESCRIPTION
## Description (optional)
This provides a link to the manifest files that we mention so that experimenter.info can get people to understand/see features that are already defined.

## Issue that this pull request resolves (optional)
n/a

## Other information (optional)
