### PR TITLE
Update capabilities.md to provide a quicker link to feature definitions

### DIFF
--- a/docs/homepage/capabilities.md
+++ b/docs/homepage/capabilities.md
@@ -42,5 +42,8 @@ Nimbus is a full-featured experimentation platform that provides configuration, 
   - Focus Andriod
   - Focus iOS
 
+## Current feature support
+- [Feature definitions](https://experimenter.info/feature-definition)
+
 ## Requesting feature support
 If you aren't sure we have what you need, pop into #ask-experimenter with your questions or [file an issue](https://mozilla-hub.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10203&issuetype=10097) 


### PR DESCRIPTION
## Description (optional)
Added "Current feature support" as a category, and a link to the page within experimenter.info that gets people to be able to find the current definitions.

## Issue that this pull request resolves (optional)
n/a