### PR TITLE
Add messaging journey doc

### DIFF
--- a/docs/messaging/messaging-journey.md
+++ b/docs/messaging/messaging-journey.md
@@ -1,0 +1,11 @@
+---
+id: messaging-journey
+title: Messaging Journey
+slug: /messaging/messaging-journey
+---
+From inception to launch, a message goes through the below three steps for Firefox Desktop:
+## Message Design
+
+## Running an Experiment
+
+## Message in Firefox

--- a/sidebars.js
+++ b/sidebars.js
@@ -87,6 +87,7 @@ module.exports = {
                   "label": "Messaging Experiments on Firefox Desktop",
                   items: [
                     "messaging/messaging-surfaces",
+                    "messaging/messaging-journey",
                     "messaging/display-logic",
                     "messaging/telemetry",
                     "messaging/groups-and-campaigns",


### PR DESCRIPTION
## Description (optional)

- Add `Messaging Journey` doc template under `Experimentation Workflow` > `Implementing` > `Messaging Experiments on Firefox Desktop` on sidebar

## Issue that this pull request resolves (optional)

## Other information (optional)
<img width="1316" alt="image" src="https://user-images.githubusercontent.com/17807246/227312064-dbf498da-ecdc-47d7-abb7-8cac38aeae0b.png">