### PR TITLE
Add link to experimenter sequence diagrams under Experimenter deep dive topics

### DIFF
--- a/docs/deep-dives/experimenter/sequence-diagrams.mdx
+++ b/docs/deep-dives/experimenter/sequence-diagrams.mdx
@@ -1,0 +1,7 @@
+---
+id: experimenter-state
+title: Experimenter state and Kinto integration
+slug: experimenter-state 
+---
+
+Learn more about experiment states, lifecycles, and workflows in Experimenter [here](https://github.com/mozilla/experimenter/blob/main/docs/experimenter/README.md)! 


### PR DESCRIPTION
## Description (optional)

- Add link to experimenter [readme](https://github.com/mozilla/experimenter/blob/main/docs/experimenter/README.md) for the sequence diagrams

## Issue that this pull request resolves (optional)

No issue