### PR TITLE
For experimenter#8727 docs(nimbus): Fix inline link to desktop migration guide

### DIFF
--- a/docs/getting-started/engineers/desktop-feature-api.mdx
+++ b/docs/getting-started/engineers/desktop-feature-api.mdx
@@ -7,7 +7,7 @@ slug: /desktop-feature-api
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-This guide will help you use the Nimbus Feature API in Desktop Firefox to run experiments, set values remotely, and manage user preferences. If you are familiar with Normandy and are trying to migrate a feature, you may want to check out the [Migration Guide for Pref Experiments](desktop-migration-guide).
+This guide will help you use the Nimbus Feature API in Desktop Firefox to run experiments, set values remotely, and manage user preferences. If you are familiar with Normandy and are trying to migrate a feature, you may want to check out the [Migration Guide for Pref Experiments](/desktop-migration-guide).
 
 ## About the Feature API
 


### PR DESCRIPTION
## Description (optional)

- Fixes the link on the [desktop feature API page](https://experimenter.info/desktop-feature-api) so that it correctly links to the [desktop migration guide](https://experimenter.info/desktop-migration-guide)

## Issue that this pull request resolves (optional)

Fixes: mozilla/experimenter#8727