### PR TITLE
Update Remote Settings URLs after GCP migration

### DIFF
--- a/docs/local-enrollment.md
+++ b/docs/local-enrollment.md
@@ -6,7 +6,7 @@ Preferences to set in Firefox
 - `app.normandy.run_interval_seconds`: 30
 - `services.settings.server`: `http://localhost:8888/v1`
 
-Note: You can also use the [remote-settings-devtool](https://github.com/mozilla-extensions/remote-settings-devtools) add-on to control some of these but the `app.normandy.run_interval_seconds` preference must still be set.
+Note: You can also use the [remote-settings-devtools](https://github.com/mozilla-extensions/remote-settings-devtools) add-on to control some of these but the `app.normandy.run_interval_seconds` preference must still be set.
 
 ## Instructions for Nimbus
 1. Set the above preferences within Firefox

--- a/docs/workflow/android-frontend-testing.md
+++ b/docs/workflow/android-frontend-testing.md
@@ -10,7 +10,7 @@ Testing the Nimbus system is out of the scope of this document.
 
 At this point, there are few if any tools for QA to use to test either of 1, or 3.
 
-However, using a local build, and by changing the `NIMBUS_URL` to the Remote Settings staging server at https://settings.stage.mozaws.net we can effectively vary the experiments definition document to test the app, and to replicate the experiment definition document used in production. This is [documented here][nimbus-url].
+However, using a local build, and by changing the `NIMBUS_URL` to the Remote Settings staging server at https://firefox.settings.services.allizom.org we can effectively vary the experiments definition document to test the app, and to replicate the experiment definition document used in production. This is [documented here][nimbus-url].
 
 Building Fenix locally is [documented in the Fenix repository][local-build].
 

--- a/docs/workflow/ios-preview-testing.md
+++ b/docs/workflow/ios-preview-testing.md
@@ -17,7 +17,7 @@ Follow the first few instructions on [the preview docs](preview.md) to get an ex
 
 Since we will be using the stage server, we want Firefox to look for experiments there. For iOS, you can do that on a local build, which you can get running by [following the instructions on the `firefox-ios` repository](https://github.com/mozilla-mobile/firefox-ios/blob/main/README.md#building-the-code)
 
-Once you have a local build using xcode, you should replace `NIMBUS_URL` with `https://settings.stage.mozaws.net/v1/`. You can set that on `info.plist`, which lies in the `Client` directory once you have the project setup. `NIMBUS_URL` will have an initial value of `$(NIMBUS_URL)`, replace that with the setting server's url.
+Once you have a local build using xcode, you should replace `NIMBUS_URL` with `https://firefox.settings.services.allizom.org/v1/`. You can set that on `info.plist`, which lies in the `Client` directory once you have the project setup. `NIMBUS_URL` will have an initial value of `$(NIMBUS_URL)`, replace that with the setting server's url.
 
 ## Accessing the secret menu
 


### PR DESCRIPTION
Supports https://mozilla-hub.atlassian.net/browse/OPST-977