### PR TITLE
Fixing the pngs on the nimbus-cli docs

### DIFF
--- a/docs/deep-dives/mobile/nimbus-cli/10-install.mdx
+++ b/docs/deep-dives/mobile/nimbus-cli/10-install.mdx
@@ -60,13 +60,13 @@ Usage: nimbus-cli [OPTIONS] --app <APP> --channel <CHANNEL> <COMMAND>
 
 The installation script tries to mitigate this, but on first run, macOS may give you a warning:
 
-<img src="/static/img/nimbus-cli/show-in-finder-dialog.png" width="300px"/>
+<img title="Show in Finder" src="/img/nimbus-cli/show-in-finder-dialog.png"/>
 
 - Click on "Show in Finder"
 - Right click on the `nimbus-cli` icon
 - Select "Open"
 
-<img src="/static/img/nimbus-cli/open-anyway-dialog.png" width="300px"/>
+<img title="Open anyway dialog" src="/img/nimbus-cli/open-anyway-dialog.png"/> 
 
 - Confirm that you Trust this Developer.
 


### PR DESCRIPTION
## Description (optional)

- Fixing the png's -- they are rendering correctly locally but not showing up on main

<img width="936" alt="image" src="https://github.com/mozilla/experimenter-docs/assets/43795363/03eb86b6-70bf-4ae9-96df-fe60f6bdce64">


## Issue that this pull request resolves (optional)

N/A

## Other information (optional)

N/A