### PR TITLE
For #460: Remove future work section for rollouts

### DIFF
--- a/docs/deep-dives/experimenter/rollouts.mdx
+++ b/docs/deep-dives/experimenter/rollouts.mdx
@@ -6,8 +6,6 @@ slug: rollouts
 
 # Rollouts
 
-> 💡  Note: this feature is still in progress. See "Future work".
-
 :::tip
 Want more info on rollouts?
 Reach out to us in [`#ask-experimenter`](https://mozilla.slack.com/archives/CF94YGE03) on Slack. 
@@ -118,12 +116,6 @@ Experimenter currently supports the following platforms:
 - Focus iOS
 
 The minimum version supported for rollouts on all platforms (listed above) is currently 105. See [Experimenter](https://github.com/mozilla/experimenter/blob/main/app/experimenter/experiments/constants.py#L370) for more details.
-
-### Future work
-
-- [Differentiate opt-out support](https://mozilla-hub.atlassian.net/browse/EXP-2554) for experiments vs rollouts
-- [Separation of concerns](https://mozilla-hub.atlassian.net/browse/EXP-2566): separating experiment and rollout UI
-
 
 ### Automated analysis
 


### PR DESCRIPTION
## Issue that this pull request resolves (optional)

Fixes #460 - the rollouts work is complete now, so we don't need this warning & future work section in the docs