### PR TITLE
Add cirrus and experimenter to the glossary

### DIFF
--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -6,11 +6,13 @@ slug: /glossary
 
 * **Behavioral targeting**: [here](/mobile-behavioral-targeting)
 * **Bucketing**: [here](/bucketing)
+* **Cirrus**: The codename of Nimbus for Web applications. [PRD](https://docs.google.com/document/d/1bg7GUoGeGusiSHE945P0XWkX_beGDQCb7gTMImliI44/edit#heading=h.hs9kv3uaq67s) and [ADR](https://docs.google.com/document/d/1ub46GXVz0rD6vsdS85UF_LvUfJItMwE9jicFCXc1jvw/edit)
 * **Co-enrolling**: [here](/fml/coenrolling-features)
 * **Custom targeting**: coming soon
    * [Targeting attributes](https://firefox-source-docs.mozilla.org/browser/components/newtab/content-src/asrouter/docs/targeting-attributes.html)
    * [Mobile messaging behavioral targeting](/mobile-behavioral-targeting)
    * See also: "Targeting Considerations" on the Nimbus Experiment Brief template available [here](/for-product#where-do-i-start)
+* **Experimenter**: This refers to the frontend website (experimenter.services.mozilla.com/) specifically, whereas 'Nimbus' refers to the experimentation system as a whole (the SDK, FML, and web frontend).
 * **First-run experiment**: [here](/mobile-first-run-experiments)
 * **Feature Manifest Language (FML)**: [here](/fml-spec)
 * **Jetstream**: see more [here](/jetstream/jetstream)


### PR DESCRIPTION
## Description (optional)

- Add "cirrus" and "experimenter" to the glossary
