### PR TITLE
Update desktop-feature-api.mdx

### DIFF
--- a/docs/getting-started/engineers/desktop-feature-api.mdx
+++ b/docs/getting-started/engineers/desktop-feature-api.mdx
@@ -319,7 +319,7 @@ Stop listening for changes.
 NimbusFeatures.myFeature.onUpdate(aListener);
 
 // Later
-NimbusFeatures.myFeature.off(aListener);
+NimbusFeatures.myFeature.offUpdate(aListener);
 ```
 
 </TabItem>


### PR DESCRIPTION
## Description (optional)

In Javascript. `NimbusFeatures.myFeature.off` does not work on Desktop. 

The API call should be `NimbusFeatures.myFeature.offUpdate` as it was changed in this patch: https://phabricator.services.mozilla.com/differential/changeset/?ref=6175315