### PR TITLE
Add docs for FML new pref-key property

### DIFF
--- a/docs/deep-dives/specifications/fml/fml-imports.mdx
+++ b/docs/deep-dives/specifications/fml/fml-imports.mdx
@@ -23,6 +23,9 @@ It allows for experimentation in the re-usable and library codebases that makes 
 
 It enables cross-platform re-use of data definitions and schemas which will in turn, make it easier to reason about experimental features by experiment owners.
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 ## Goals
 
 - The `nimbus.fml.yaml` file should be composable such the monolithic file can be broken up in to smaller pieces, potentially to live closer to the code it's configuring.

--- a/docs/deep-dives/specifications/fml/fml-spec.mdx
+++ b/docs/deep-dives/specifications/fml/fml-spec.mdx
@@ -9,6 +9,9 @@ sidebar_position: 1
 
 This document is the specification for the Feature Manifest Language for use with the Nimbus SDK. It is implemented by the `nimbus-fml` tool, which is a Rust [command line app run](/fml/fml-cli) at build time of a mobile app.
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 ## Introduction
 
 Nimbus is an experimentation platform to allow product owners to easily run experiments on their mobile apps.
@@ -215,7 +218,7 @@ features:
         default: false
       max-age-in-days:
         description: The number of days a single piece of content is indexed for.
-        type: Double
+        type: Int
         default: 28.0
 ```
 
@@ -262,7 +265,7 @@ if (!spotlightConfig.enabled) {
 
 // val item = SearchableItem(…)
 
-val oneDayInSeconds: Int = 24 * 60 * 60
+val oneDayInSeconds: Long = 24 * 60 * 60
 val maxAgeInSeconds = spotlightConfig.maxAgeInDays * oneDayInSeconds
 item.expirationDate = Date().addSeconds(maxAgeInSeconds)
 ```
@@ -299,8 +302,8 @@ struct SpotlightSearch {
         self.variables?.getBool("enabled") ?? false
     }()
 
-    lazy var keepNumDays: Double = {
-        self.variables?.getDouble("enabled") ?? 28.0
+    lazy var keepNumDays: Int = {
+        self.variables?.getInt("enabled") ?? 28.0
     }()
 }
 ```
@@ -314,8 +317,8 @@ data class SpotlightSearch(private val variables: Variables? = null) {
         self.variables?.getBool("enabled") ?? false
     }
 
-    var keepNumDays: Double by lazy {
-        self.variables?.getDouble("enabled") ?? 28.0
+    var keepNumDays: Int by lazy {
+        self.variables?.getInt("enabled") ?? 28.0
     }
 }
 ```
@@ -733,3 +736,7 @@ In order to drive a better experience for `experimenter` (the Nimbus web server)
 ### Feature co-enrollment
 
 A feature which allows co-enrollment allows a client to be enrolled in any number of experiments/rollouts for that feature. See [Co-enrolling Features](/fml/coenrolling-features) for more information.
+
+### Feature variables configured by preferences
+
+Some feature variables may be optionally driven by preferences (`UserDefaults` or `SharedPrefences`). There are some restrictions and nuances here, so see [the documentation for more information](/fml/using-prefs).

--- a/docs/deep-dives/specifications/fml/fml-spec.mdx
+++ b/docs/deep-dives/specifications/fml/fml-spec.mdx
@@ -219,7 +219,7 @@ features:
       max-age-in-days:
         description: The number of days a single piece of content is indexed for.
         type: Int
-        default: 28.0
+        default: 28
 ```
 
 Each variable has a `description`, a `type` and `default` value.
@@ -302,8 +302,8 @@ struct SpotlightSearch {
         self.variables?.getBool("enabled") ?? false
     }()
 
-    lazy var keepNumDays: Int = {
-        self.variables?.getInt("enabled") ?? 28.0
+    lazy var maxAgeInDays: Int = {
+        self.variables?.getInt("max-age-in-days") ?? 28
     }()
 }
 ```
@@ -317,8 +317,8 @@ data class SpotlightSearch(private val variables: Variables? = null) {
         self.variables?.getBool("enabled") ?? false
     }
 
-    var keepNumDays: Int by lazy {
-        self.variables?.getInt("enabled") ?? 28.0
+    var maxAgeInDays: Int by lazy {
+        self.variables?.getInt("max-age-in-days") ?? 28
     }
 }
 ```
@@ -420,8 +420,8 @@ features:
         default: false
       max-age-in-days:
         description: The number of days a single piece of content is indexed for.
-        type: Double
-        default: 28.0
+        type: Int
+        default: 28
       item-thumbnail:
         description: "The icon that appears in the Spotlight search results.
           Note that changing this does not change already indexed content."

--- a/docs/deep-dives/specifications/fml/using-prefs.mdx
+++ b/docs/deep-dives/specifications/fml/using-prefs.mdx
@@ -1,0 +1,174 @@
+---
+id: using-prefs
+title: Using prefs to override feature variables
+slug: /fml/using-prefs
+sidebar_position: 6
+---
+
+This page details adding `pref-key` to a feature definition. This cause the FML generated code to check the user preferences (`UserDefaults` or `SharedPrefences`) __before__ checking the Nimbus configuration store or the default.
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+## Setting up
+
+The app's preferences object need to be added to the `NimbusBuilder` call:
+
+<Tabs
+  defaultValue="swift"
+  values={[
+    { label: "Swift", value: "swift" },
+    { label: "Kotlin", value: "kotlin" },
+  ]
+}>
+<TabItem value="swift">
+
+```swift
+NimbusBuilder()
+    .with(userDefaults: UserDefaults.standard) // or alternative
+    .build(…)
+```
+
+Without this line, the default value used is `UserDefaults.standard`.
+</TabItem>
+<TabItem value="kotlin">
+
+```kotlin
+NimbusBuilder(context).apply {
+        sharedPreferences = … // the shared preferences being used for this app
+    }
+    .build(…)
+```
+
+Without this line, the default value used in `null`, and this feature will not function.
+</TabItem>
+</Tabs>
+
+These should be readable by Nimbus, but writeable by the rest of the app. For best effect, these should be the same preferences that drive the Settings screens.
+
+Once the preference object is available to nimbus, you can add `pref-key`s to feature variables.
+
+## Adding a `pref-key` to a feature variable definitions
+
+The `pref-key` can be specified by top level feature variables:
+
+```yaml
+features:
+    sample-feature:
+        variables:
+            is-enabled:
+                type: Boolean
+                default: false
+                pref-key: sample-feature.isEnabled
+```
+
+The generated API is used in the same way as without the `pref-key`:
+
+<Tabs
+  defaultValue="swift"
+  values={[
+    { label: "Swift", value: "swift" },
+    { label: "Kotlin", value: "kotlin" },
+  ]
+}>
+<TabItem value="swift">
+
+```swift
+let feature = FxNimbus.shared.features.sampleFeature.value()
+if feature.isEnabled {
+    // Do something because the feature has been enabled.
+}
+```
+</TabItem>
+<TabItem value="kotlin">
+
+```kotlin
+val feature = FxNimbus.features.sampleFeature.value()
+if (feature.isEnabled) {
+    // Do something because the feature has been enabled.
+}
+```
+</TabItem>
+</Tabs>
+
+However, now, the call to `feature.isEnabled` is overridden by the preference held at `sample-feature.isEnabled`.
+
+This is availble for types that are supported by preferences: `Boolean`, `Int`, `String` and `Text`.
+
+### Generated code sketch
+
+The generated code looks approximately like:
+<Tabs
+  defaultValue="swift"
+  values={[
+    { label: "Swift", value: "swift" },
+    { label: "Kotlin", value: "kotlin" },
+  ]
+}>
+<TabItem value="swift">
+
+```swift
+let isEnabled: Boolean {
+    return prefs.getBoolean("sample-feature.isEnabled") ??
+        json.getBoolean("is-enabled") ??
+        defaults.isEnabled
+}
+```
+
+Without the `pref-key`:
+
+```swift
+let isEnabled: Boolean {
+    return json.getBoolean("is-enabled") ??
+        defaults.isEnabled
+}
+```
+</TabItem>
+<TabItem value="kotlin">
+
+```kotlin
+val isEnabled: Boolean =
+    prefs.getBoolean("sample-feature.isEnabled") ?:
+    json.getBoolean("is-enabled") ?:
+    defaults.isEnabled
+```
+
+Without the `pref-key`:
+
+```kotlin
+val isEnabled: Boolean =
+    json.getBoolean("is-enabled") ?:
+    defaults.isEnabled
+```
+
+</TabItem>
+</Tabs>
+
+### Limitations
+
+This is available for feature variables (not nested `Objects` fields), and only for scalar types.
+
+It is not available for structural types (i.e. `Option<T>`, `List<T>` or `Map<String, T>`).
+
+:::tip Feedback welcome
+
+If there is demand for it, then support for these types and places will be considered.
+
+Similarly, we're looking for feedback on how to make this API or generated code better.
+:::
+
+## Additional effects of experiment events
+
+If the user sets any of the named preferences for the feature, then the feature is said to be user-modified.
+
+This is exposed in the `isModified()` method of the feature.
+
+User-modified features will not emit exposure events.
+
+:::warning experimental
+**Question**: Should user-modification be allowed for the general population? i.e. can we add these toggles to a public facing settings screen?
+
+**Answer**: Currently, it is recommended that user-modification should be exposed only in Secret Settings screens.
+
+This is not suitable as building an opt out of all experiments involving the feature.
+:::

--- a/docs/deep-dives/specifications/fml/using-prefs.mdx
+++ b/docs/deep-dives/specifications/fml/using-prefs.mdx
@@ -12,7 +12,7 @@ import TabItem from "@theme/TabItem";
 
 ## Setting up
 
-The app's preferences object need to be added to the `NimbusBuilder` call:
+The app's preferences object needs to be added to the `NimbusBuilder` call:
 
 <Tabs
   defaultValue="swift"
@@ -93,7 +93,7 @@ if (feature.isEnabled) {
 
 However, now, the call to `feature.isEnabled` is overridden by the preference held at `sample-feature.isEnabled`.
 
-This is availble for types that are supported by preferences: `Boolean`, `Int`, `String` and `Text`.
+This is available for types that are supported by preferences: `Boolean`, `Int`, `String` and `Text`.
 
 ### Generated code sketch
 

--- a/docs/getting-started/engineers/01-android-integration.md
+++ b/docs/getting-started/engineers/01-android-integration.md
@@ -224,11 +224,16 @@ Adding the `usePreviewCollection` flag allows the builder to configure a `Nimbus
         initialExperiments = R.raw.initial_experiments
         usePreviewCollection = context.settings().nimbusUsePreview
         isFirstRun = isAppFirstRun
+        sharedPreferences = context.settings().preferences
+        // Optional callbacks.
         onCreateCallback = { nimbus ->
-            FxNimbus.initialize { nimbus }
+            // called when nimbus is set up
+        }
+        onFetchCallback = {
+            // called each time the app fetches experiments
         }
         onApplyCallback = {
-            FxNimbus.invalidateCachedValues()
+            // called each time the applies the fetched experiments.
         }
     }.build(appInfo)
 ```

--- a/docs/getting-started/engineers/02-ios-integration.md
+++ b/docs/getting-started/engineers/02-ios-integration.md
@@ -223,6 +223,7 @@ public static var nimbus: NimbusInterface = {
         .with(initialExperiments: Bundle.main.url(forResource: "initial_experiments", withExtension: "json"))
         .isFirstRun(isFirstRun)
         .with(bundles: bundles)
+        .with(userDefaults: UserDefaults.standard)
         .with(featureManifest: AppConfig.shared)
         .build(appInfo: appSettings)
 }()

--- a/docs/workflow/implementing/messaging/mobile-messaging.mdx
+++ b/docs/workflow/implementing/messaging/mobile-messaging.mdx
@@ -36,6 +36,8 @@ It is also a living document:
 You can view a demo of sending a survey on mobile [here](https://mozilla.zoom.us/rec/share/CafQjaLn09BtbPvOphePVizKe49IrRF2QHtYcc5zs4XlbmEhHzulcohmvC1WUV49.ZBKmiSNkaw7kbIeJ)
 Access Passcode: 9Zx9Lg&M
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 #### Edit history
 


### PR DESCRIPTION
## Description (optional)

This adds new developer documentation for the `pref-key` property in FML, introduced in https://github.com/mozilla/application-services/pull/5862.

Question for @danielkberry : are we able to use `pref-key` to expose preferences to the general user (not just in Secret Settings menus)?


## Issue that this pull request resolves (optional)

This will link to and close an issue in GitHub. Replace `experimenter` with the repository where the issue lives and replace `0000` with the issue number. Remove this section if not applicable.

Closes: mozilla/experimenter#0000

## Other information (optional)

Any other information or requests important to this pull request. Remove this section if not applicable.

If you're not certain that your Markdown will render correctly, you can include this line:
I have not ran the project locally with my changes and it would be be ideal for the reviewer to check into my branch and ensure images etc. are rendering as expected.
