### PR TITLE
Add string-alias documentation

### DIFF
--- a/docs/cookbook/fml/growable-collections.mdx
+++ b/docs/cookbook/fml/growable-collections.mdx
@@ -15,7 +15,7 @@ For example,
 
 ## Solution
 
-Use a type of `Map<String, T>`.
+Use a type of `Map<String, T>`, with a string-alias.
 
 ```yaml
 ---
@@ -28,7 +28,8 @@ features:
     variables:
       asset-urls:
         description: A collection of downloadable assets
-        type: Map<String, String>
+        type: Map<AssetName, String>
+        string-alias: AssetName
         default: {}
   defaults:
     - channel: debug
@@ -84,7 +85,8 @@ The feature manifest defines the shape i.e. the types, of the complete configura
 ```yaml
       asset-urls:
         description: A collection of downloadable assets
-        type: Map<String, String>
+        type: Map<AssetName, String>
+        string-alias: AssetName
         default: {}
 ```
 
@@ -173,7 +175,7 @@ record an exposure only when that asset is being shown. We can do this by adding
 ```yaml
       asset-under-experiment:
         description: The key into the asset urls map of the asset we wish to test.
-        type: Option<String>
+        type: Option<AssetName>
         default: null
 ```
 

--- a/docs/deep-dives/specifications/fml/fml-front-end-format.md
+++ b/docs/deep-dives/specifications/fml/fml-front-end-format.md
@@ -2,7 +2,7 @@
 id: fml-front-end-format
 title: Feature Manifest Language Front-end Format As YAML
 slug: /fml/fml-front-end-format
-sidebar_position: 5
+sidebar_position: 10
 ---
 
 - Status: accepted

--- a/docs/deep-dives/specifications/fml/fml-spec.mdx
+++ b/docs/deep-dives/specifications/fml/fml-spec.mdx
@@ -671,6 +671,54 @@ Maps with enum keys must have a default value for every variant of the enum.
 
 Since maps are backed by JSON objects, the merge/patching allows entries to come from the manifest, experiments and rollouts simultaneously.
 
+### String aliasing
+
+As the size and complexity of the feature grows, different parts of the configuration are tied together with `String` keys.
+
+`string-alias` is a type annotation for FML feature variables. It's effect is to define a `String` type with a limited set of valid strings.
+
+This is like enums, in that it defines a set of valid values, but unlike enums in that the set is not known at build time.
+
+```yaml
+features:
+  onboarding:
+    description: A feature to vary the appearance of all toasts and modal dialogs
+    variables:
+      queries:
+        description: A map of named JEXL queries
+        type: Map<QueryName, String>
+        string-alias: QueryName
+        default:
+          ALWAYS: 'true'
+          CHRISTMAS_DAY: '-12-25' in date_string
+      cards:
+        type: Map<CardKey, CardData>
+        string-alias: CardKey
+        default: {}
+
+objects:
+  CardData:
+    description: An onboarding card, which can be optionally displayed or hidden.
+    fields:
+      trigger-if:
+        description: Show this message if the list of queries are all true.
+        type: List<QueryName>
+        default:
+          - ALWAYS
+      except-if:
+        description: Hide this message if any of this list of queries are true.
+        type: List<QueryName>
+        default: []
+      …
+```
+
+In the above example, `QueryName` is given as the set of strings that are keys for the feature's `queries` map.
+
+When used in the card`s `trigger-if` and `except-if` lists, the FML will validate that each item is found in the map. In this manner, experiment owners can
+add queries to the map and safely use them when defining new `cards`, without needing a rebuild or re-release of the code.
+
+For more, please see [the `string-alias` documentation](/fml/string-alias).
+
 ## Merging other FML files into this one
 
 This `include` property is a list of files which will be merged with this one. The files may be relative to this one, absolute or URLs.

--- a/docs/deep-dives/specifications/fml/fml-string-alias.md
+++ b/docs/deep-dives/specifications/fml/fml-string-alias.md
@@ -1,0 +1,181 @@
+---
+id: fml-string-alias
+title: Using string alias
+slug: /fml/string-alias
+sidebar_position: 6
+---
+
+`string-alias` is a type alias annotations for feature variables in the feature manifest language. It defines a named set of strings which can be used and validated elsewhere in the feature manifest.
+
+It is named as a special case of typealiasing found in many languages.
+
+```kt
+typealias QueryName = String
+val queries = mapOf<QueryName, String>()
+```
+
+In this kotlin example above, we are able to use `QueryName` wherever we're able to use `String`, and vice versa: there is nothing else linking `QueryName` with `queries`.
+
+## `string-alias` defines a named set of valid strings
+
+In FML, the `string-alias` belongs to the variable definition.
+
+```yaml
+    queries:
+        string-alias: QueryName
+        type: Map<QueryName, String>
+        default:
+            ALWAYS: 'true'
+```
+
+Here, `QueryName` is defined as the set of `String`s that are keys in the `queries` map.
+
+In the example above, we're defining a map of named queries. The default has one entry in.
+
+Where `QueryName` is used again, its value is checked against this membership test, by the FML:
+
+```yaml
+    available-if:
+        type: QueryName
+        default: ALWAYS
+```
+
+Note that had the `queries` map been empty, we could not have provided a default value for `available-if`.
+
+Now that the `QueryName` string-alias has been defined, it can be used in conjunction with any structural type definition for example:
+
+```yaml
+    available-if:
+        type: Option<QueryName>
+        default: null
+```
+
+This means that `available-if` can be either a valid `QueryName` or `null`.
+
+
+```yaml
+    available-if:
+        type: List<QueryName>
+        default: []
+```
+
+This means that `available-if` can be a list of valid `QueryName` strings.
+
+### The named set is used to validate strings by experimenter
+
+Over time, the number of queries can grow in the FML:
+
+```yaml
+    queries:
+        string-alias: QueryName
+        type: Map<QueryName, String>
+        default:
+            ALWAYS: 'true'
+            USER_RECENTLY_INSTALLED: days_since_install < 7
+            USER_EN_SPEAKER: 'en' in locale
+            USER_DE_SPEAKER: 'de' in locale
+```
+
+
+Defining `QueryName` allows experimenter to validate a feature configuration before it reaches the application:
+
+```json
+{
+    "available-if": [
+        "USER_RECENTLY_INSTALLED",
+        "USER_ES_SPEAKER"
+    ]
+}
+```
+
+In the above example, experimenter shows the user an error:
+
+```
+Invalid value "USER_ES_SPEAKER" for type QueryName; did you mean one of "ALWAYS", "USER_DE_SPEAKER", "USER_EN_SPEAKER" or "USER_RECENTLY_INSTALLED"?
+```
+
+### The named set can be added to by FML authors or experiment owners
+
+This can be fixed by adding a query to the `queries` map in the FML file _or_ the user can add it directly in the feature configuration:
+
+```json
+{
+    "queries": {
+        "USER_ES_SPEAKER": "'es' in locale"
+    },
+    "available-if": [
+        "USER_RECENTLY_INSTALLED",
+        "USER_ES_SPEAKER"
+    ]
+}
+```
+
+## Defining the named set of valid strings
+
+We've seen how a string-alias can be used, and how `QueryName` was defined as a key in a map.
+
+The valid set of strings can be defined by any existing [structural types](/fml-spec#structural-types). Some contrived examples follow:
+
+```yaml
+    surfaces:
+        type: List<SurfaceName>
+        string-alias: SurfaceName
+        default: []
+```
+
+Any use of `SurfaceName` must be contained in the list of `surfaces`. This may be used as an alternative to an enum, used in a library, but whose variants are defined in an app, thereby breaking the compile-time dependency from library to app.
+
+```yaml
+    experiment-slug:
+        type: ExperimentSlug
+        string-alias: ExperimentSlug
+        default: '{experiment}'
+```
+
+Any use of `ExperimentSlug` _must_ be the default value. In conjunction with an `Option<>` at the usage site, this lets us specify either an exact value or `null`.
+
+For completeness, the string alias named set can be defined as:
+- `MyStringAlias`: a single value
+- `Map<MyStringAlias, _>`: keys in a map
+- `Map<_, MyStringAlias>`: values in a map
+- `List<MyStringAlias>`: items in a list
+- `Option<MyStringAliase>`: an option
+- `Map<_, List<StringAlias>>`: combinations of these structural types.
+
+:::warning Restriction
+Only one string-alias can be defined per feature variable. The following– using one variable to define two named sets of strings– is not possible at this time.
+
+```yaml
+    available-events:
+        string-alias: EventCategory, EventName
+        type: Map<EventCategory, List<EventName>>
+```
+:::
+
+### String aliases can be used in nested objects
+
+```yaml
+features:
+    my-onboarding-feature:
+        variables:
+            queries:
+                type: Map<QueryName>
+                string-alias: QueryName
+                default: {}
+            cards:
+                type: Map<CardKey, CardData>
+                string-alias: CardKey
+objects:
+    CardData:
+        fields:
+            exclude-if:
+                type: List<QueryName>
+                default: []
+            include-if:
+                type: List<QueryName>
+                default: []
+```
+
+:::warning Restriction
+String-alias can only be defined in a feature variable. The object can only be used, directly or indirectly, by a feature which defines the string-aliases it uses.
+:::


### PR DESCRIPTION
Fixes [EXP-4057](https://mozilla-hub.atlassian.net/browse/EXP-4057).

[Rendered page](https://github.com/mozilla/experimenter-docs/blob/c74787e5568e300142ffacaf30267b38e522be9f/docs/deep-dives/specifications/fml/fml-string-alias.md).

## Issue that this pull request resolves (optional)

This will link to and close an issue in GitHub. Replace `experimenter` with the repository where the issue lives and replace `0000` with the issue number. Remove this section if not applicable.

Closes: mozilla/experimenter#0000

## Other information (optional)

Any other information or requests important to this pull request. Remove this section if not applicable.

If you're not certain that your Markdown will render correctly, you can include this line:
I have not ran the project locally with my changes and it would be be ideal for the reviewer to check into my branch and ensure images etc. are rendering as expected.
