### PR TITLE
Document nimbus-fml info command

### DIFF
--- a/docs/deep-dives/specifications/fml/fml-cli.mdx
+++ b/docs/deep-dives/specifications/fml/fml-cli.mdx
@@ -34,7 +34,7 @@ Adding [repo files](/fml/fml-paths) can be done with one or more `--repo-file` a
 
 ### Getting different versions of the same manifest
 
-For [remote manifests]((/fml/fml-paths)), the default branch to fetch from is `main`. This can be changed with the `--ref` option.
+For [remote manifests](/fml/fml-paths), the default branch to fetch from is `main`. This can be changed with the `--ref` option.
 
 ```
 % nimbus-fml generate --language <LANGUAGE> --ref releases_v118 @mozilla-mobile/firefox-android/fenix/app/nimbus.fml.yaml <OUTPUT>
@@ -108,3 +108,76 @@ To help this, the `single-file` command is used to merge all imports and include
 ```
 % nimbus-fml single-file --channel release @mozilla-mobile/firefox-android/fenix/app/nimbus.fml.yaml single-file.fml.yaml
 ```
+
+## Generating a machine readable overview of a feature
+
+```sh
+nimbus-fml info [--channel CHANNEL] [--json] <MANIFEST> [--feature FEATURE]
+```
+
+This prints a simplified YAML or JSON representation for each feature. e.g.
+
+```json
+{
+  "file": "https://raw.githubusercontent.com/mozilla-mobile/firefox-android/main/fenix/app/nimbus.fml.yaml",
+  "features": {
+    "homescreen": {
+      "description": "The homescreen that the user goes to when they press home or new tab.",
+      "types": [
+        "Boolean",
+        "HomeScreenSection",
+        "Map<HomeScreenSection, Boolean>"
+      ],
+      "hashes": {
+        "schema": "7a15570b",
+        "defaults": "423ab0bd"
+      }
+    }
+  }
+}
+```
+
+The `hashes` object shows truncated SHA256 hashes for:
+
+- the schema (the types, variable names, the enum variants available)
+- the defaults (the default values of the feature variables)
+
+Changes in the schema hash might indicate a change in the feature code.
+Changes in the defaults hash would indicate a different configuration being used for the same code.
+
+:::info
+Changes in the schema hash will almost always be accompanied by a change in the defaults hash, with the exception of changing variable types from
+a `String` type to a `string-alias` type (or vice-versa).
+:::
+
+The `types` list is a sorted list of the types involved used to define the feature. This list may be used as a proxy for a measure of complexity of the feature configuration space.
+
+In addition, [the feature metadata](/fml/feature-metadata) is also displayed.
+
+If a `--feature` argument is supplied, then restrict the output to just this feature.
+
+If a `--channel` argument is supplied, then use this channel. This will affect the `defaults` hashes.
+
+:::info Using `info` with JQ
+You can use `--json` JQ to output some interesting data:
+
+Get the features for this app:
+
+```sh
+nimbus-fml info <INPUT> --json | jq '.features|keys'
+```
+
+Get the channels for this app:
+
+```sh
+nimbus-fml channels <INPUT> --json
+```
+
+Get the hashes for just the `homescreen` feature:
+
+```sh
+nimbus-fml info <INPUT> --json | jq '.features.homescreen.hashes'
+```
+:::
+
+`--cache-dir`, `--ref` and `--repo-file` arguments are also supported.

--- a/docs/deep-dives/specifications/fml/fml-cli.mdx
+++ b/docs/deep-dives/specifications/fml/fml-cli.mdx
@@ -36,13 +36,13 @@ Adding [repo files](/fml/fml-paths) can be done with one or more `--repo-file` a
 
 For [remote manifests](/fml/fml-paths), the default branch to fetch from is `main`. This can be changed with the `--ref` option.
 
-```
-% nimbus-fml generate --language <LANGUAGE> --ref releases_v118 @mozilla-mobile/firefox-android/fenix/app/nimbus.fml.yaml <OUTPUT>
-```
-
 Using a `ref` is equivalent to taking the remote repo of the manifest path and creating a `repo-file` with that repo mapped to the given `ref`.
 
-This command uses feature manifest from the `releases_v118` branch of the https://github.com/mozilla-mobile/firefox-android repository.
+This command uses feature manifest from the `releases_v118` branch of the https://github.com/mozilla-mobile/firefox-android repository:
+
+```sh
+% nimbus-fml generate --language <LANGUAGE> --ref releases_v118 @mozilla-mobile/firefox-android/fenix/app/nimbus.fml.yaml <OUTPUT>
+```
 
 ### Caching remote files
 
@@ -144,10 +144,10 @@ The `hashes` object shows truncated SHA256 hashes for:
 - the schema (the types, variable names, the enum variants available)
 - the defaults (the default values of the feature variables)
 
-Changes in the **schema hash** might indicate a change in the **feature code**. Changes in the **defaults hash** would indicate a **different configuration being used** for the same code.
-
 :::tip
-Changes in the schema hash will almost always be accompanied by a change in the defaults hash, with the exception of changing variable types from
+- Changes in the **schema hash** might indicate a change in the **feature code**.
+- Changes in the **defaults hash** would indicate a **different configuration being used** for the same code.
+- Changes in the schema hash will almost always be accompanied by a change in the defaults hash, with the exception of changing variable types from
 a `String` type to a `string-alias` type (or vice-versa).
 :::
 

--- a/docs/deep-dives/specifications/fml/fml-cli.mdx
+++ b/docs/deep-dives/specifications/fml/fml-cli.mdx
@@ -66,7 +66,7 @@ For legacy reasons, this is a different format of yaml file, which should be che
 
 This should only be called at the application level, with the one main fml file as an input.
 
-`--cache-dir`, `--ref` and `--repo-file` arguments are also supported.
+`--cache-dir`, `--ref`, and `--repo-file` arguments are also supported.
 
 ## Validating a manifest file
 
@@ -112,7 +112,7 @@ To help this, the `single-file` command is used to merge all imports and include
 ## Generating a machine readable overview of a feature
 
 ```sh
-nimbus-fml info [--channel CHANNEL] [--json] <MANIFEST> [--feature FEATURE]
+% nimbus-fml info [--channel CHANNEL] [--json] <MANIFEST> [--feature FEATURE]
 ```
 
 This prints a simplified YAML or JSON representation for each feature. e.g.
@@ -137,20 +137,25 @@ This prints a simplified YAML or JSON representation for each feature. e.g.
 }
 ```
 
+### Hashes
+
 The `hashes` object shows truncated SHA256 hashes for:
 
 - the schema (the types, variable names, the enum variants available)
 - the defaults (the default values of the feature variables)
 
-Changes in the schema hash might indicate a change in the feature code.
-Changes in the defaults hash would indicate a different configuration being used for the same code.
+Changes in the **schema hash** might indicate a change in the **feature code**. Changes in the **defaults hash** would indicate a **different configuration being used** for the same code.
 
-:::info
+:::tip
 Changes in the schema hash will almost always be accompanied by a change in the defaults hash, with the exception of changing variable types from
 a `String` type to a `string-alias` type (or vice-versa).
 :::
 
+### Types
+
 The `types` list is a sorted list of the types involved used to define the feature. This list may be used as a proxy for a measure of complexity of the feature configuration space.
+
+### Feature metadata
 
 In addition, [the feature metadata](/fml/feature-metadata) is also displayed.
 
@@ -164,19 +169,19 @@ You can use `--json` JQ to output some interesting data:
 Get the features for this app:
 
 ```sh
-nimbus-fml info <INPUT> --json | jq '.features|keys'
+% nimbus-fml info <INPUT> --json | jq '.features|keys'
 ```
 
 Get the channels for this app:
 
 ```sh
-nimbus-fml channels <INPUT> --json
+% nimbus-fml channels <INPUT> --json
 ```
 
 Get the hashes for just the `homescreen` feature:
 
 ```sh
-nimbus-fml info <INPUT> --json | jq '.features.homescreen.hashes'
+% nimbus-fml info <INPUT> --json | jq '.features.homescreen.hashes'
 ```
 :::
 

--- a/docs/deep-dives/specifications/fml/fml-cli.mdx
+++ b/docs/deep-dives/specifications/fml/fml-cli.mdx
@@ -32,6 +32,18 @@ Adding [repo files](/fml/fml-paths) can be done with one or more `--repo-file` a
 % nimbus-fml generate --language <LANGUAGE> --repo-file ./app-structure.json <INPUT> <OUTPUT>
 ```
 
+### Getting different versions of the same manifest
+
+For [remote manifests]((/fml/fml-paths)), the default branch to fetch from is `main`. This can be changed with the `--ref` option.
+
+```
+% nimbus-fml generate --language <LANGUAGE> --ref releases_v118 @mozilla-mobile/firefox-android/fenix/app/nimbus.fml.yaml <OUTPUT>
+```
+
+Using a `ref` is equivalent to taking the remote repo of the manifest path and creating a `repo-file` with that repo mapped to the given `ref`.
+
+This command uses feature manifest from the `releases_v118` branch of the https://github.com/mozilla-mobile/firefox-android repository.
+
 ### Caching remote files
 
 ```
@@ -40,7 +52,7 @@ Adding [repo files](/fml/fml-paths) can be done with one or more `--repo-file` a
 
 [For `include` and `import` directives in the FML](/fml/fml-imports-and-includes), a remote file may be referenced. The cache directory is a local cache of these remote files.
 
-For each of the following, `--cache-dir` and `--repo-file` flags are supported.
+For each of the following, `--ref`, `--cache-dir` and `--repo-file` flags are supported.
 
 ## Generating a manifest file for experimenter
 
@@ -54,7 +66,7 @@ For legacy reasons, this is a different format of yaml file, which should be che
 
 This should only be called at the application level, with the one main fml file as an input.
 
-`--cache-dir` and `--repo-file` arguments are also supported.
+`--cache-dir`, `--ref` and `--repo-file` arguments are also supported.
 
 ## Validating a manifest file
 


### PR DESCRIPTION
Fixes [EXP-4100](https://mozilla-hub.atlassian.net/browse/EXP-4100).

## Description

This command documents the `nimbus-fml` `info` command added in https://github.com/mozilla/application-services/pull/5967.

## Issue that this pull request resolves (optional)

This will link to and close an issue in GitHub. Replace `experimenter` with the repository where the issue lives and replace `0000` with the issue number. Remove this section if not applicable.

Closes: mozilla/experimenter#0000

## Other information (optional)

Any other information or requests important to this pull request. Remove this section if not applicable.

If you're not certain that your Markdown will render correctly, you can include this line:
I have not ran the project locally with my changes and it would be be ideal for the reviewer to check into my branch and ensure images etc. are rendering as expected.
