### PR TITLE
Update 02-ios-integration.md

### DIFF
--- a/docs/getting-started/engineers/02-ios-integration.md
+++ b/docs/getting-started/engineers/02-ios-integration.md
@@ -148,6 +148,11 @@ Astute readers will notice that when `n = 0`, i.e. the very first time the app i
 
 The `initial_experiments.json` file can be downloaded, either as part of the build, or in an automated/timed job. e.g. this is the [Github Action workflow used by Firefox for iOS](https://github.com/mozilla-mobile/firefox-ios/blob/main/.github/workflows/update-nimbus-experiments.yml).
 
+#### To check if the firstrun experiment merged into beta to catch the next release
+First run experiments need to be in the beta build 8-11 days before release, so that they are in the release candidate.  Final build happens 8 days before release on Monday - so best to get in and uplift approved by Friday at the latest.  
+
+After the change is made in Nimbus/Experimenter to launch, enrollment end, or end the experiment - a github action kicks off the PR automatically to update 'initial_experiments.json'.  Then a mobile engineer needs to r+ that PR and request uplift to Beta.  If you replace 'version number' in the following file name, you can check this file to see if the experiment config is in the right state before release candidate build https://raw.githubusercontent.com/mozilla-mobile/firefox-ios/release/v'version number'/Client/Experiments/initial_experiments.json.
+
 ### Using the experiments preview collection
 
 The preview collection is a staging area for new experiments to be tested on the device. This should be toggleable via the UI, but should trigger a restart.


### PR DESCRIPTION
adding a way to tell if your experiment will be on the next train

## Description (optional)

-

## Issue that this pull request resolves (optional)

This will link to and close an issue in GitHub. Replace `experimenter` with the repository where the issue lives and replace `0000` with the issue number. Remove this section if not applicable.

Closes: mozilla/experimenter#0000

## Other information (optional)

Any other information or requests important to this pull request. Remove this section if not applicable.

If you're not certain that your Markdown will render correctly, you can include this line:
I have not ran the project locally with my changes and it would be be ideal for the reviewer to check into my branch and ensure images etc. are rendering as expected.
