### PR TITLE
Add `hasExposure: false` to pref-setting example feature

### DIFF
--- a/docs/deep-dives/desktop/desktop-pref-experiments.md
+++ b/docs/deep-dives/desktop/desktop-pref-experiments.md
@@ -19,6 +19,7 @@ experiments should set the value to a JSON string.
 pref-feature:
   description: A description of my feature
   owner: whoami@mozilla.com
+  hasExposure: false
   variables:
     string:
       description: A variable setting a string pref.


### PR DESCRIPTION
Per the schema for a feature manifest, `hasExposure` [is required](https://searchfox.org/mozilla-central/rev/6b1e306175c2284958fb185bab388021e2890ed0/toolkit/components/nimbus/schemas/ExperimentFeatureManifest.schema.json#114). So this is adding it to the example code.