### PR TITLE
Remove notice about setPref not working with json variables

### DIFF
--- a/docs/deep-dives/desktop/desktop-pref-experiments.md
+++ b/docs/deep-dives/desktop/desktop-pref-experiments.md
@@ -8,10 +8,10 @@ As of Firefox 107, Nimbus supports experiments that set preferences on Desktop.
 Unlike Normandy, Nimbus cannot set arbitrary preferences; instead, the
 preferences that may be set are determined by the feature manifest.
 
-Each variable in a Nimbus feature can set a single pref. Integer, string, and
-boolean typed variables are supported but JSON variables are not supported. If
-you want to set a JSON value to a pref, a string variable should be used and
-experiments should set the value to a JSON string.
+Each variable in a Nimbus feature can set a single pref of any type.
+
+NB: Support for JSON variables was added in Firefox 126. The value of the pref
+will be `JSON.stringify(value)`.
 
 ## Example Feature
 


### PR DESCRIPTION
Bug 1887732 [1] is adding support for setPref json variables.

https://bugzilla.mozilla.org/show_bug.cgi?id=1887732
