### PR TITLE
Fix enroll file parameter in CLI docs

### DIFF
--- a/docs/deep-dives/mobile/nimbus-cli/50-working-with-files.mdx
+++ b/docs/deep-dives/mobile/nimbus-cli/50-working-with-files.mdx
@@ -92,8 +92,9 @@ The `enroll` command takes `--file` parameter, so you can enroll from recipes st
 
 ```sh
 nimbus-cli --app fenix --channel developer \
+    enroll \
     --file archived.json \
-    enroll android-research-surface-validation --branch treatment
+    android-research-surface-validation --branch treatment
 ```
 
 ## `apply-file`


### PR DESCRIPTION
The --file parameter has to come after the enroll command but the docs mistakenly put it before

