### PR TITLE
Fix links to asrouter pages

### DIFF
--- a/docs/deep-dives/desktop/desktop-targeting-debug.md
+++ b/docs/deep-dives/desktop/desktop-targeting-debug.md
@@ -17,7 +17,7 @@ slug: /desktop-targeting-debug
 
 ## Targeting
 
-Available targeting attributes are [documented in firefox-source-docs](https://firefox-source-docs.mozilla.org/browser/components/newtab/content-src/asrouter/docs/targeting-attributes.html).
+Available targeting attributes are [documented in firefox-source-docs](https://firefox-source-docs.mozilla.org/browser/components/asrouter/docs/targeting-attributes.html).
 
 Inside the textarea targeting expressions can be written and evaluated using the `Evaluate` button.
 

--- a/docs/workflow/implementing/messaging/desktop-messaging-journey.md
+++ b/docs/workflow/implementing/messaging/desktop-messaging-journey.md
@@ -24,7 +24,7 @@ Once the experiment has successfully concluded and analysis shows promising resu
 * [`browser/components/asrouter/modules/FeatureCalloutMessages.sys.mjs`][FeatureCalloutMessages]
 * [`browser/components/asrouter/modules/OnboardingMessageProvider.sys.mjs`][OnboardingMessageProvider]
 
-Visit [Firefox Source docs](https://firefox-source-docs.mozilla.org/browser/components/newtab/docs/index.html): newtab for details on how to develop within our components.
+Visit [Firefox Source docs](https://firefox-source-docs.mozilla.org/browser/components/asrouter/docs/index.html): newtab for details on how to develop within our components.
 
 [AboutWelcomeDefaults]: https://searchfox.org/mozilla-central/source/browser/components/aboutwelcome/modules/AboutWelcomeDefaults.sys.mjs
 [FeatureCalloutMessages]: https://searchfox.org/mozilla-central/source/browser/components/asrouter/modules/FeatureCalloutMessages.sys.mjs


### PR DESCRIPTION
The newtab component was split into asrouter and newtab and this fixes some of the links to go to the correct place.