### PR TITLE
Update stage links to webservices domain

### DIFF
--- a/docs/additional-links/system-architecture.mdx
+++ b/docs/additional-links/system-architecture.mdx
@@ -12,7 +12,7 @@ slug: /system-architecture
 ### Experimenter (AKA Nimbus Console)
 This is the interface used by experiment owners and reviewers to capture details about the experiments and the specifics about how to launch it.  
 This is the interface to start, end enrollment, end, and look at results. 
-[stage](https://stage.experimenter.nonprod.dataops.mozgcp.net/) and [production](https://experimenter.services.mozilla.com/nimbus/)
+[stage](https://stage.experimenter.nonprod.webservices.mozgcp.net/) and [production](https://experimenter.services.mozilla.com/nimbus/)
 
 ### Remote Settings
 This is a shared service at Mozilla - that is used to remotely configure the clients. 

--- a/docs/deep-dives/desktop/desktop-incident-response.md
+++ b/docs/deep-dives/desktop/desktop-incident-response.md
@@ -258,6 +258,6 @@ submitted with the following data:
 [jsonschema]: https://searchfox.org/mozilla-central/source/toolkit/components/nimbus/schemas/PrefFlipsFeature.schema.json
 [setPref]: /desktop-pref-experiments
 [advanced-targeting]: /targeting/advanced-targeting#answer
-[stage]: https://stage.experimenter.nonprod.dataops.mozgcp.net/nimbus/
+[stage]: https://stage.experimenter.nonprod.webservices.mozgcp.net/nimbus/
 [glean-telemetry]: https://dictionary.telemetry.mozilla.org/apps/firefox_desktop/metrics/nimbus_events_unenrollment
 [legacy-telemetry]: https://probes.telemetry.mozilla.org/?search=unenroll&view=detail&probeId=event%2Fnormandy.unenroll%23unenroll

--- a/docs/getting-started/access.md
+++ b/docs/getting-started/access.md
@@ -26,7 +26,7 @@ Assuming you have been vouched for by a Nimbus administrator + a Product Owner (
 #### Testing Review Workflow on Staging
 
 - Connect to the VPN
-- Go to [Nimbus Staging](https://stage.experimenter.nonprod.dataops.mozgcp.net/nimbus/) (not Production!). Ask someone to create a dummy experiment and request review.
+- Go to [Nimbus Staging](https://stage.experimenter.nonprod.webservices.mozgcp.net/nimbus/) (not Production!). Ask someone to create a dummy experiment and request review.
 - Click "Approve" on the dummy experiment, and then "Open Remote Settings":
   ![image](https://user-images.githubusercontent.com/1455535/144130977-149c2e65-4995-4040-a840-ea2baa0e3dc4.png)
   ![image](https://user-images.githubusercontent.com/1455535/144131295-8469c508-11d6-49e1-91d7-0bcf5d81efa6.png)

--- a/docs/workflow/overview.md
+++ b/docs/workflow/overview.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 ---
 
 ## Experimentation Workflow 
-[Click here for 5 minute recorded overview](https://mozilla.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=4d337632-a0bd-4be7-bee8-ae5b017134ae&start=0) of Experiment Workflow .  Here's a direct link to view the full [Workflow Miro board](https://miro.com/app/board/uXjVOJ3IYRA=/).  Here's [the link](https://stage.experimenter.nonprod.dataops.mozgcp.net/nimbus/) to the Stage environment for Nimbus console.
+[Click here for 5 minute recorded overview](https://mozilla.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=4d337632-a0bd-4be7-bee8-ae5b017134ae&start=0) of Experiment Workflow .  Here's a direct link to view the full [Workflow Miro board](https://miro.com/app/board/uXjVOJ3IYRA=/).  Here's [the link](https://stage.experimenter.nonprod.webservices.mozgcp.net/nimbus/) to the Stage environment for Nimbus console.
 
 <div class="miro-container"> 
 <iframe class="responsive-iframe" src="https://miro.com/app/live-embed/uXjVOJ3IYRA=/?moveToViewport=-2130,380,5949,3025&embedAutoplay=true" frameBorder="0" scrolling="no"></iframe>
@@ -19,6 +19,6 @@ If the experiment was run with Nimbus, check out the [directory of live and comp
 
 ## Links to experimentation tools
 Here is the [link to Nimbus Console](https://experimenter.services.mozilla.com/nimbus/) - where new experiments are created, reviewed/launched, monitored, and eventually have the results.
-Here is the [link to STAGE for Nimbus Console](https://stage.experimenter.nonprod.dataops.mozgcp.net/nimbus/).  This is where you can create experiments and learn how to interact with the tools without impacting production users.
+Here is the [link to STAGE for Nimbus Console](https://stage.experimenter.nonprod.webservices.mozgcp.net/nimbus/).  This is where you can create experiments and learn how to interact with the tools without impacting production users.
 
 If the experiment is not yet live, you will probably be able to find a relevant Jira ticket on this [Data Science Experimentation Collaboration Board](https://mozilla-hub.atlassian.net/jira/software/c/projects/DS/boards/258)

--- a/docs/workflow/testing/android-preview-testing.md
+++ b/docs/workflow/testing/android-preview-testing.md
@@ -8,7 +8,7 @@ slug: /android-preview-testing
 
 ## Launching an experiment to Preview the stage server
 
-The first step to testing the preview flow is to launch an experiment. Go to [experimenter](https://stage.experimenter.nonprod.dataops.mozgcp.net/nimbus/](https://experimenter.services.mozilla.com/nimbus/)) and create your experiment.
+The first step to testing the preview flow is to launch an experiment. Go to [experimenter](https://stage.experimenter.nonprod.webservices.mozgcp.net/nimbus/](https://experimenter.services.mozilla.com/nimbus/)) and create your experiment.
 
 For experiments that are already live, go to the summary page. For experiments that have not yet launched, you will need the author to click "Launch to Preview" on the Review & Launch page.
 

--- a/docs/workflow/testing/ios-preview-testing.md
+++ b/docs/workflow/testing/ios-preview-testing.md
@@ -8,7 +8,7 @@ slug: /ios-preview-testing
 
 ## Launching an experiment to Preview the stage server
 
-The first step to testing the preview flow is to launch an experiment. Go to [experimenter](https://stage.experimenter.nonprod.dataops.mozgcp.net/nimbus/](https://experimenter.services.mozilla.com/nimbus/)) and create your experiment.
+The first step to testing the preview flow is to launch an experiment. Go to [experimenter](https://stage.experimenter.nonprod.webservices.mozgcp.net/nimbus/](https://experimenter.services.mozilla.com/nimbus/)) and create your experiment.
 
 For experiments that are already live, go to the summary page. For experiments that have not yet launched, you will need the author to click "Launch to Preview" on the Review & Launch page.
 
@@ -44,7 +44,7 @@ You can also check out this [visual documentation](https://docs.google.com/docum
 
 - **What kind of experiment should I create?**
 
-If you would like your test to be more in-depth, we recommend you create an iOS experiment that can be directly tested on the UI. For example, you can create an `onboarding-default-browser` experiment by setting the feature config to `onboarding-default-browser` and setting the appropriate values, [check out this experiment on experimenter for a complete example](https://stage.experimenter.nonprod.dataops.mozgcp.net/nimbus/teshaqtest-preview-flow-showhide-default-browser-title-image)
+If you would like your test to be more in-depth, we recommend you create an iOS experiment that can be directly tested on the UI. For example, you can create an `onboarding-default-browser` experiment by setting the feature config to `onboarding-default-browser` and setting the appropriate values, [check out this experiment on experimenter for a complete example](https://stage.experimenter.nonprod.webservices.mozgcp.net/nimbus/teshaqtest-preview-flow-showhide-default-browser-title-image)
 
 - **I don't see my experiments on Firefox!**
 

--- a/docs/workflow/testing/testing-on-mobile.md
+++ b/docs/workflow/testing/testing-on-mobile.md
@@ -31,7 +31,7 @@ Building Fenix locally is [documented in the Fenix repository][local-build].
 
 We wish to get the app to ingest the experiment definition of our choice. Here is a sample experiment definition, which you can generate with the [staging instance of Experimenter][stage-experimenter]. 
 
-[stage-experimenter]: https://stage.experimenter.nonprod.dataops.mozgcp.net/nimbus/
+[stage-experimenter]: https://stage.experimenter.nonprod.webservices.mozgcp.net/nimbus/
 
 ```json
 {
@@ -103,7 +103,7 @@ These fields affect which OS, app and build the experiment is for. These should 
  * `channel`: this must be `nightly` or `developer`. The experimenter UI should help you select the right one.
  * `feature_id`/`featureIds`: this is the identifier of the app feature under test. This should match what is hard coded into the App. Experimenter will put these in all the right places. If the feature id is not already listed, you can [add it here][experimenter-admin].
 
-[experiment-admin]: https://stage.experimenter.nonprod.dataops.mozgcp.net/admin/
+[experiment-admin]: https://stage.experimenter.nonprod.webservices.mozgcp.net/admin/
 
 These fields affect segment the population for eligibility for the experiment, and which branch they'll be given.
 


### PR DESCRIPTION
was following docs/getting-started/access.md and noticed the stage links are broken because we were moved from dataops to webservices
