### PR TITLE
chore: apply consistent formatting to Data & Analysis

### DIFF
--- a/docs/data-analysis/auto-sizing-cli.md
+++ b/docs/data-analysis/auto-sizing-cli.md
@@ -4,13 +4,15 @@ title: Sizing CLI
 slug: /data-analysis/auto-sizing-cli
 ---
 
+The auto-sizing command-line interface provides rapid sample size calculations for simple experiments using Mozanalysis functionality.
+
 The sample size calculation functionality contained in the [Mozanalysis] library is accessible via a command-line interface (CLI), **[auto-sizing]**. This CLI is intended to enable rapid analyses for simple experiments or experiments with targeting similar to past experiments.
 
-## Sizing job configuration
+## Sizing Job Configuration
 
 The sizing CLI relies on a local TOML file to configure the job. This TOML file contains the metrics, segments, and parameters used to carry out the analysis. Sample sizes based on these parameters are calculated using the [`mozanalysis.frequentist_stats.sample_size.z_or_t_ind_sample_size_calc`](https://mozilla.github.io/mozanalysis/api/frequentist_stats/sample_size.html#mozanalysis.frequentist_stats.sample_size.z_or_t_ind_sample_size_calc) method. Note that segments in Mozanalysis refer to the filters used to identify clients that will satisfy targeting for an experiment (whereas segments in Jetstream denote groups of clients to examine during post-hoc analysis).
 
-### TOML file layout
+### TOML File Layout
 
 The TOML configuration file must contain a `metrics`, `data_sources`, `segments`, and `segments.data_sources` section, each containing the definitions for those of interest for the experiments. The definition of each of these follows the same patterns as [Jetstream], and details on how to define your own inside of the TOML file can be found [here](/data-analysis/jetstream/configuration#defining-metrics).
 
@@ -23,7 +25,7 @@ A `parameters` section in the TOML file is used to define the data collection pe
 1. `parameters.sizing`: Contains two tags, `power` and `effect_size`. These tags should contain lists of values for each parameter, and a sample size will be calculated for all metrics provided in the TOML file for each combination of power and effect size in those lists.
 2. `parameters.dates`: Contains the `start_date` (in "%Y-%m-%d" format, e.g. "2023-01-01"), `num_dates_enrollment`, and `analysis_length` values. For details on how those values are used to query historical data, see the [Mozanalysis documentation](https://experimenter.info/experiment-sizing).
 
-## CLI commands
+## CLI Commands
 
 The sizing CLI is invoked using the command `auto_sizing run`. The following options are available at invocation:
 
@@ -35,7 +37,7 @@ The sizing CLI is invoked using the command `auto_sizing run`. The following opt
 | `--target_slug` | Name for the experiment. Used when naming metrics table and output file |
 | `--local_config` | Path to the configuration TOML file |
 
-## CLI output
+## CLI Output
 
 Results for experiment sizing are saved in JSON format. If a GCP bucket is provided in the `--bucket` option at invocation, this JSON file is saved in a `sample_sizes` folder in that bucket. If no bucket is provided, the JSON results are saved to the same folder as the TOML configuration file. 
 

--- a/docs/data-analysis/data-topics/bucketing.md
+++ b/docs/data-analysis/data-topics/bucketing.md
@@ -4,7 +4,7 @@ title: Bucketing
 slug: /data-analysis/data-topics/bucketing
 ---
 
-**Bucketing** is the process of randomly assigning users to experiment branches. When a user is “bucketed” into an experiment, it means that the configuration in one of its branches (such as a change to part of the UI) can be activated, and that any interactions we record from that moment on can be associated with the experiment and branch identifier.  The concept is explained in this [video](https://mozilla.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=c5fe3f48-322f-48ca-92d8-adc8014a3cb4&start=10) / [presentation](https://docs.google.com/presentation/d/18Xid6FNyC207Hqfhm3OtVDBxNCbVx9Ku9Hvqc_PJVU4/edit#slide=id.g82761e80df_0_1948).  
+**Bucketing** is the process of randomly assigning users to experiment branches. When a user is "bucketed" into an experiment, it means that the configuration in one of its branches (such as a change to part of the UI) can be activated, and that any interactions we record from that moment on can be associated with the experiment and branch identifier.  The concept is explained in this [video](https://mozilla.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=c5fe3f48-322f-48ca-92d8-adc8014a3cb4&start=10) / [presentation](https://docs.google.com/presentation/d/18Xid6FNyC207Hqfhm3OtVDBxNCbVx9Ku9Hvqc_PJVU4/edit#slide=id.g82761e80df_0_1948).  
 
 :::info which experiments?
 This documentation applies to experiments launched to Desktop, iOS, and Android Firefox through the "Nimbus" or "Normandy" systems. Differences between platforms are noted when relevant.
@@ -139,13 +139,13 @@ We will assign 20% of the buckets to branch `a`, 50% to `b`, and 30% to `c`. We 
 
 ```
 
-### Controlling interactions
+## Controlling Interactions
 
 By default, all experiments are allowed to interact and clients can bucket into multiple experiments simultaneously. However, sometimes we _do_ want experiments to be exclusive, such as when they change the same set of variables.
 
 In practice, we have three methods of preventing interactions between experiments:
 
-#### Bucket range exclusion
+### Bucket Range Exclusion
 
 Experiments that configure the same namespace will bucket identically for the same user identifier. This means we can exclude experiments by giving the same namespace and have them specify non-interacting ranges (start / count).
 
@@ -178,13 +178,13 @@ Say we generate a value of `4562` from our hash on a given client. The client is
 
 Note that we _always_ re-randomize branch assignment, so we can't isolate based on branch.
 
-#### Client-side rules
+### Client-side Rules
 
 In Nimbus, clients are prevented from enrolling into two experiments that target the same feature with a simple check during enrollment. For example, a user cannot be enrolled in two experiments that change the `aboutwelcome` feature.
 
 In Normandy, clients are prevented from enrolling in two experiments that change the same preference.
 
-#### Targeting exclusion
+### Targeting Exclusion
 
 For specific experiments that should be excluded from others, a targeting expression can be included with a specific experiment identifier:
 

--- a/docs/data-analysis/data-topics/missing_exposures.md
+++ b/docs/data-analysis/data-topics/missing_exposures.md
@@ -13,9 +13,9 @@ If you see missing results like those shown in the image below, then
 
 ![An image of the Nimbus UI showing results when exposures are missing. The results show zero clients enrolled and that the system is unable to calculate results](../../../static/img/deep-dives/missing_exposures_analysis.png)
 
-## Configuring experiments for exposure-based analysis
+## Configuring Experiments for Exposure-Based Analysis
 
-### Configuring exposures post-hoc
+### Configuring Exposures Post-Hoc
 
 If the experiment is live or finished, then the only option is to define an `ExposureSignal` as a custom config (see point 2 above). In this approach, we tell the automated analysis system which telemetry probe represents exposure for this experiment. Note that this must be a telemetry probe that was collected while the experiment was live. For assistance with this step, contact your supporting data scientist through the experiment's DS Jira ticket or ask in [#ask-experimenter](https://mozilla.slack.com/archives/CF94YGE03).
 
@@ -23,11 +23,11 @@ If the experiment is live or finished, then the only option is to define an `Exp
 Exposure is the point in time _immediately prior_ to recieving the treatment. We cannot use any post-treatment telemetry as the definition of exposure as that risks creating a biased comparison and results in non-causal inference. For example, an experiment in which the treatment gets a message to suggest using a new feature. In that experiment, exposure is _being shown a message_ (treatment branch) or _would have been shown a message_ (control branch). Exposure **is not** _using the new feature_. If we compare users who used the feature we'll be comparing users who discovered the feature organically (control branch) against a treatment branch containing organic discoverers and users who tried the feature out as a result of seeing the message.
 :::
 
-#### What if no telemetry exists which can be proxied for exposure?
+#### What If No Telemetry Exists Which Can Be Proxied for Exposure?
 
 In that case, fall back on enrollments-based analysis (click the `enrollments` radio button in the Analysis Basis selector) and see the [section on interpretation discussion](#enrollments-vs-exposures-analysis) below. Additionally, aim to have future experiments configured for exposures-based analysis.
 
-### Preparing future experiments for exposure-based analysis
+### Preparing Future Experiments for Exposure-Based Analysis
 
 For experiments that have not yet launched, it is preferred to implement exposures client-side by calling the appropriate method from the Nimbus SDK (see point 1 above). Once implemented, these events will get picked up by the automated analysis system, so no custom analysis configuration is required.
 

--- a/docs/data-analysis/data-topics/preenrollment_bias.md
+++ b/docs/data-analysis/data-topics/preenrollment_bias.md
@@ -4,8 +4,6 @@ title: Preenrollment Bias
 slug: /data-analysis/data-topics/preenrollment_bias
 ---
 
-# Automatically Countering Preenrollment Bias
-
 TL;DR: Nimbus has the capability to adjust metrics to account for preenrollment bias/natural randomization variability and to improve the precision of inferences, when possible. Currently this is configured by default for guardrails (averages only) but can also be used for custom analyses. This is expected to reduce the frequency of false positives, of which we believe many were caused by natural randomization variability.
 
 ## Preenrollment Bias
@@ -14,7 +12,7 @@ In order to generate evidence for a causal hypothesis, we must guarantee that al
 
 Randomization provides a guarantee of balance on average and across large numbers of experiments, but in practice, for any given experiment and confounding dimension there is the possibility of imbalance. This imbalance (or rather, confounding) presents a challenge to our goal of gathering causal evidence. An imbalance observed during the treatment period is indistinguishable from a treatment effect. In the next section (Retrospective A/A Tests) we provide a method for detecting these situations.
 
-## Retrospective A/A tests
+## Retrospective A/A Tests
 
 User behavior tends to be consistent over time. We've found week-to-week correlations of up to 80% for our key guardrail metrics. Given this strong correlation, we can look for evidence of imbalance during the _pre-experiment period_. We've been using the term preenrollment bias, though [others](https://www.statsig.com/blog/pre-experiment-bias-detection-statsig) use pre-experiment bias.
 
@@ -37,7 +35,7 @@ WHERE 1=1
 ORDER BY metric, branch, statistic
 ```
 
-## Covariate Adjustment & CUPED
+## Covariate Adjustment and CUPED
 
 What if the Retrospective A/A test flags evidence of an imbalance? Should we have to discard that metric from our analysis completely? Luckily, there exist techniques to adjust for pre-experiment information. The most common/popular of these is [CUPED](https://www.statsig.com/blog/cuped). We have implemented a CUPED-like technique using linear models.
 
@@ -58,9 +56,9 @@ Where $z_i$ is the metric of interest ($y$) for the $i$-th unit as measured duri
 1. Adjusted to account for pre-experiment information
 2. Benefit from an increase in precision.
 
-### Configuring covariate adjustment
+### Configuring Covariate Adjustment
 
-#### Adjusting a new metric for preenrollment bias
+#### Adjusting a New Metric for Preenrollment Bias
 
 To perform adjustment for a new metric, you can write/edit the [custom config](../jetstream/configuration.md#custom-experiment-configurations) to do 2 things: 1) configure your metric to be calculated over the preenrollment period (that is, perform the retrospective A/A test) and 2) configure the adjustment.
 
@@ -90,7 +88,7 @@ Currently, the custom configs only support adjusting a during-treatment metric u
 As of February 2025, the execution order of analysis periods is not guaranteed. This means that, when rerunning an analysis for an experiment, it's possible for the computation for the during-treatment analysis to execute before the preenrollment has finished. This will result in the adjustment not being performed. That is, Jetstream will automatically fall back to unadjusted inferences. You can determine if Jetstream fell back by either examining the logs (see [dashboard](https://mozilla.cloud.looker.com/dashboards/246?Experiment=&Timestamp+Date=14+day&Log+Level=ERROR%2CWARNING)) or by comparing to the unadjusted confidence intervals (which will be identical if adjustment was not performed).
 :::
 
-#### Custom adjustments
+#### Custom Adjustments
 
 We have built tooling to perform these calculations and these methods can be used manually by data scientists to perform custom adjusted inferences. For example, suppose one wanted to control for machine type (cores) in an experiment trying to drive performance.
 

--- a/docs/data-analysis/data-topics/sizing.md
+++ b/docs/data-analysis/data-topics/sizing.md
@@ -63,7 +63,7 @@ In this pattern, we can run a sequence of experiments (2 or more) of increasing 
 2. A very small experiment (<1%), followed by a small experiment (<5%), followed by a very large experiment.
    - Similar to above, but further limits the risk of the 5% experiment through the use of a very small, preliminary experiment. See for example the [rollout of ToU](https://docs.google.com/presentation/d/1vTRx6kv3oAvIZSNcle6YhhMTQ8_5nLn77PNqCFuAQc8/edit#slide=id.g32cf211b9a1_3_92) which used a 4-stage design.
 
-### Exploratory then Explanatory
+### Exploratory Then Explanatory
 
 In this pattern, we run an initial small experiment with many branches to identify the winning variant (using a more sensitive, experiment or feature specific metric) and follow-up with a larger experiment to maximize the power of measuring guardrail impacts. For example:
 
@@ -76,7 +76,7 @@ In this pattern, we run an initial small experiment with many branches to identi
 
 In this pattern, a very small experiment (~1% or so) is run prior to the main experiment. This can estimate opportunity size/exposure rates and derisk a larger experiment. This is a special form of the Sequentially Larger pattern.
 
-## Same design, more insights
+## Same Design, More Insights
 
 In this section, we explore methods to increase the learnings from a given design.
 
@@ -88,30 +88,30 @@ Retention (down funnel) is difficult to move, but metrics up funnel are easier t
 
 ## Frequently Asked Questions
 
-### Q: I'm concerned that the proposed size might not be large enough to measure statistical significance. Or equivalently: I ran an experiment and the results were not stat sig, what can I do?
+### Q: I'm Concerned That the Proposed Size Might Not Be Large Enough to Measure Statistical Significance. Or Equivalently: I Ran an Experiment and the Results Were Not Stat Sig, What Can I Do?
 
 A: you can follow-on with a larger experiment, now that the variant has been de-risked.
 
-### Q: very few users are expected to be exposed to/interact with my experiment.
+### Q: Very Few Users Are Expected to Be Exposed to/Interact With My Experiment.
 
 A: in that case, the risk is also low. You may need to run a large experiment (up to even enrolling all users who meet a criteria) in order to measure any impacts. Also consider the opportunity size though: if very few users could benefit from the experiment that limits the potential value.
 
-### Q: my experiment is very risky, what should I do?
+### Q: My Experiment Is Very Risky, What Should I Do?
 
 A: run a staged design, with the number of stages and the sizes influenced by the level of risk.
 
-### Q: I have a lot of variants, I'm not sure which will be the best, and I want to maximize the ability to measure impact.
+### Q: I Have a Lot of Variants, I'm Not Sure Which Will Be the Best, and I Want to Maximize the Ability to Measure Impact.
 
 A: consider the Exploratory then Explanatory design mentioned above.
 
-### Q: I don't know how many users will interact or be exposed.
+### Q: I Don't Know How Many Users Will Interact or Be Exposed.
 
 A: follow the Smoke Test pattern.
 
-### Q: My experiment is low risk and I need to maximize potential achieved value and realize value quickly.
+### Q: My Experiment Is Low Risk and I Need to Maximize Potential Achieved Value and Realize Value Quickly.
 
 A: Consider the Holdback Pattern where you hold 1%-10% of users back as control and deliver the feature the remaining 90%-99%.
 
-### Q: I've read all of this, my experiment is quite low risk, I mostly care about measuring potential value (positive impacts) to guardrails, there aren't any special considerations, I just need to get a number and you're blocking me.
+### Q: I've Read All of This, My Experiment Is Quite Low Risk, I Mostly Care About Measuring Potential Value (Positive Impacts) to Guardrails, There Aren't Any Special Considerations, I Just Need to Get a Number and You're Blocking Me.
 
 A: pick a size in the range of 1%-10% per branch, depending on your personal risk tolerance. Consider following up with a secondary experiment if results from the first are inconclusive.

--- a/docs/data-analysis/jetstream/adding-a-platform.md
+++ b/docs/data-analysis/jetstream/adding-a-platform.md
@@ -1,26 +1,27 @@
 ---
 id: adding-a-platform
 sidebar_position: 10
-title: Applications
+title: Adding a Platform
 slug: /data-analysis/jetstream/adding-a-platform
 ---
 
+This guide explains how to configure Jetstream to run analyses for experiments launched on a new application or platform.
+
 Jetstream runs analyses for experiments launched on several different applications, such as Fenix or Firefox Desktop. When adding a new application in Experimenter, the new application also needs to be configured in Jetstream to enable automated analyses for launched experiments.
 
----
-## Add support for application in jetstream
-- Inside [platform_config.toml](https://github.com/mozilla/jetstream/blob/main/platform_config.toml) add the configuration for the new application
+## Add Support for Platform in Jetstream
 
+Inside [platform_config.toml](https://github.com/mozilla/jetstream/blob/main/platform_config.toml) add the configuration for the new platform.
 
-An example of desktop configuration
+An example of desktop configuration:
 ```
 [platform.firefox_desktop]
 enrollments_query_type = "normandy"
 app_id = "firefox-desktop"
 ```
 
----
-### Configuration breakdown
-- `[platform.platform_name]` - Specify application name
+## Configuration Breakdown
+
+- `[platform.platform_name]` - Specify platform name
 - `enrollments_query_type` - whether enrollments should be determined based on Glean events (`glean-event`) data or Normandy data (`normandy`) (default: `glean-event`)
 - `app_id` - application ID as defined in [probe-scraper repository.yaml](https://github.com/mozilla/probe-scraper/blob/main/repositories.yaml)

--- a/docs/data-analysis/jetstream/configuration.md
+++ b/docs/data-analysis/jetstream/configuration.md
@@ -1,4 +1,4 @@
---- 
+---
 sidebar_position: 5
 slug: /data-analysis/jetstream/configuration
 id: configuration
@@ -139,7 +139,7 @@ You should not define a `start_date` and `end_date` in your Jetstream configurat
 unless it is important for your analysis that the deployment period is not the same as the analysis period.
 
 
-### Metrics section
+## Metrics Section
 
 The metrics section allows you to specify and define the metrics that you're collecting,
 the statistical summaries that you'd like applied to them, and any filters that you need.
@@ -169,7 +169,7 @@ overall = ["uri_count", "search_count"]
 
 [jetstream-dtmo]: https://docs.telemetry.mozilla.org/datasets/jetstream.html
 
-### Defining metrics
+## Defining Metrics
 
 You can define a new metric by adding a new section with a name like
 
@@ -274,7 +274,7 @@ data_source = "main"
 [metrics.ever_clicked_cows.statistics.binomial]
 ```
 
-### Defining data sources
+## Defining Data Sources
 
 Most of the regular data sources are already defined in mozanalysis. 
 See what [pre-defined data sources are available](https://mozilla.github.io/metric-hub/data_sources/firefox_desktop/) for your platform.
@@ -304,7 +304,7 @@ Then, your new metric can refer to it like `data_source = "my_cool_data_source"`
 
 *(**Importantly**, the metric's configured data_source must support a superset of the metric's analysis_units.)*
 
-### Defining segments
+## Defining Segments
 
 You can define new segments, just like you can define new metrics.  
 Segments allow you to look at the experiment results by the defined segments (or groups of users).  An example would be new users versus existing users - or segmenting results by country.   
@@ -336,7 +336,7 @@ on the date of enrollment.
 [moza-segment-ds]: https://mozilla.github.io/mozanalysis/api/segments.html#mozanalysis.segments.SegmentDataSource
 
 
-### Outcome snippets
+## Outcome Snippets
 
 Outcome snippets, which define a collection of summaries with a common theme (e.g. "performace", "Picture in Picture use"),
 are stored in the `outcomes/` directory and file names serve as unique identifiers. Outcome snippets are organized in different
@@ -386,7 +386,7 @@ data_source = "search_clients_engines_sources_daily"
 [metrics.urlbar_amazon_search_count.statistics.deciles]
 ```
 
-### Overwriting Outcomes parameters
+## Overwriting Outcomes Parameters
 
 __distinct_by_branch set to false__ example:
 
@@ -425,7 +425,7 @@ value.experiment_branch_name_2 = "amazon"
 COUNTIF(CASE e.branch_name WHEN "experiment_branch_name_1" THEN "google" WHEN "experiment_branch_name_2" THEN "amazon" END)
 ```
 
-### Defining Exposure Signals
+## Defining Exposure Signals
 
 Many Nimbus features will send a [Nimbus exposure event] automatically when the feature configuration is consulted;
 these are `normandy#expose` events on desktop and `nimbus_events.exposure` events in Glean.
@@ -484,7 +484,7 @@ window_end = "analysis_window_end"
 
 Results for exposure based metrics are currently not visualized in Experimenter. To access results, the BigQuery tables need to be queried directly.
 
-## Testing configurations
+## Testing Configurations
 
 For more information on how to test configurations see [Testing Jetstream Configs](./testing)
 

--- a/docs/data-analysis/jetstream/data-products.md
+++ b/docs/data-analysis/jetstream/data-products.md
@@ -13,11 +13,11 @@ Jetstream writes analysis results and enrollments information to BigQuery. Stati
 
 The datasets that back the Experimenter results dashboards are available in BigQuery in the `mozanalysis` dataset in `moz-fx-data-experiments`. [Technical documentation][jetstream-dtmo] is available in the Mozilla data docs.
 
-### Monitoring Datasets
+## Monitoring Datasets
 
 Datasets used for monitoring the operation of Jetstream are part of the `monitoring` dataset in `moz-fx-data-experiments`.
 
-#### Error Logs
+## Error Logs
 
 Jetstream logs errors and warning encountered during its analysis runs to `monitoring.logs`. This datasets is used as basis for the [Jetstream error dashboard] and for setting up alerts.
 
@@ -34,7 +34,7 @@ The `logs` table has the following schema:
 | `func_name`             | `STRING`    | Name the Jetstream function the exception was raised  |
 | `exception_type`        | `STRING`    | Class name the exception raised                       |
 
-#### Query Cost
+## Query Cost
 
 The `monitoring.query_cost_v1` dataset contains the cost of each query run when analysing experiments. The dataset is updated daily and scrapes the cost information from the BigQuery logs. The query for determining the costs is part of [bigquery-etl](https://github.com/mozilla/bigquery-etl/tree/main/sql/moz-fx-data-experiments/monitoring/query_cost_v1). The dataset is basis for the [jetstream cost monitoring dashboard](https://sql.telemetry.mozilla.org/dashboard/jetstream-cost) and [alerts set up](https://sql.telemetry.mozilla.org/alerts/91) to send notifications when an analysis query exceeds a certain threshold.
 
@@ -48,7 +48,7 @@ The `query_cost_v1` table has the following schema:
 | `total_bytes_processed` | `INT64`     | Number of bytes the query processed                   |
 | `cost_usd`              | `FLOAT`     | Cost of the query in USD based on [BigQuery pricing]  |
 
-#### Experimenter Experiments
+## Experimenter Experiments
 
 For monitoring Nimbus experiments, some common failure cases are exposed as part of the [Experiments Enrollments dashboard](https://mozilla.cloud.looker.com/dashboards-next/216). These monitoring rules will require access to collected experiments enrollment data which is available in `monitoring.experimenter_experiments_v1`. This dataset is part of [bigquery-etl](https://github.com/mozilla/bigquery-etl/tree/main/sql/moz-fx-data-experiments/monitoring/experimenter_experiments_v1) and updated every 10 minutes by fetching data from the Experimenter API.
 
@@ -56,7 +56,7 @@ For monitoring Nimbus experiments, some common failure cases are exposed as part
 
 Jetstream exports statistics data and metadata of analysed experiments to the `mozanalysis` GCS bucket.
 
-### Statistics Data
+## Statistics Data
 
 After each analysis run has completed, Jetstream exports the statistics results of each experiments to the `statistics` sub-directory as JSON. The JSON files follow the naming format:
 
@@ -64,7 +64,7 @@ After each analysis run has completed, Jetstream exports the statistics results 
 
 Each file contains a JSON object for every row in the corresponding statistics table. The JSON files are pulled in by Experimenter and used for visualizing results on the Experimenter results page.
 
-### Metadata
+## Metadata
 
 Metadata of analyzed experiments contains information about all metrics and outcomes that are computed during any analysis period. Metadata is written to JSON files into the `metadata` sub-directory with the following naming schema:
 

--- a/docs/data-analysis/jetstream/operations.md
+++ b/docs/data-analysis/jetstream/operations.md
@@ -22,7 +22,7 @@ To ensure analysis results are available in a timely manner, Jetstream implement
 * Parallelization of experiment analyses using [Argo](https://argoproj.github.io/)
 * Parallelization of lower-level calculations (statistics, segments, ...) using [Dask](https://dask.org/)
 
-### Parallelizing experiment analyses
+## Parallelizing Experiment Analyses
 
 [Argo](https://argoproj.github.io/) is a light-weight workflow engine for orchestrating parallel jobs on Kubernetes and is capable of creating tasks dynamically that will be executed in parallel. Using Argo, the analyses for different experiments and analysis dates are split into separate jobs that run in parallel on the `jetstream` Kubernetes cluster in the `moz-fx-data-experiment-analysis` GCP project.
 
@@ -31,7 +31,7 @@ The full workflow definition is defined in [the `workflows/run.yaml` file](https
 
 Depending on how Jetstream is invoked (`rerun`, `run-argo`, or `rerun_config_changed`), Jetstream will determine the dates and experiments that are to be analyzed and injects them as parameters into `run.yaml` before launching the workflow. Argo will create separate jobs for each experiment and each analysis date. Once the analysis is complete, data gets exported as JSON to GCS.
 
-### Parallelizing lower-level calculations
+## Parallelizing Lower-Level Calculations
 
 In addition to running experiment analyses in parallel, [Dask](https://dask.org/) is used to parallelize lower-level calculations. The following steps could be executed in parallel:
 * Analyses for each analysis period (daily, 28day, weekly, overall)
@@ -61,7 +61,7 @@ Argo provides a Web UI to access running workflows. Users need to authenticate u
 * Open [https://localhost:2746](https://localhost:2746)
 * Use the generated Bearer token (including the word `Bearer`) for authentication
 
-### Deleting Old Workflows
+## Deleting Old Workflows
 
 * The Workflow UI might get less responsive the more workflows have been run in the past
 * To delete workflows that are older than 4 days run:
@@ -75,7 +75,7 @@ kubectl get wf -o go-template -n argo --template '{{range .items}}{{.metadata.na
 
 Argo updates should be tested on a separate cluster before applying them to production. Jetstream has some custom logic to connect to clusters and issue workflows that might be incompatible with future versions of Argo.
 
-### Preparation 
+## Preparation 
 * Ensure `kubectl` is using the correct cluster context (e.g., to switch between dev and prod clusters)
 	* `kubectl config get-contexts`
 	* `kubectl config use-context <context>`
@@ -83,13 +83,13 @@ Argo updates should be tested on a separate cluster before applying them to prod
 	* `kubectl -n argo exec $(kubectl get pod -n argo -l 'app=argo-server' --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}') -- argo version`
 * Check for breaking changes in the Argo [Upgrade Guide](https://argo-workflows.readthedocs.io/en/latest/upgrading/)
 
-### Perform Upgrade
+## Perform Upgrade
 * Find kubectl command to install/upgrade from the [Argo releases](https://github.com/argoproj/argo-workflows/releases) page
 	* Should look like: `kubectl apply -n argo -f https://github.com/argoproj/argo-workflows/releases/download/v3.6.7/install.yaml`
 		* Change version number to most recent release
 * The GKE cluster itself is updated automatically by GCP
 
-### Post Upgrade
+## Post Upgrade
 * Verify version number with command above and by checking UI
 * Run a test workflow by sending a small analysis job to the cluster with `jetstream run-argo` for a single experiment and date
 	* **Important** Use configuration options to ensure production data is not overwritten
@@ -102,7 +102,7 @@ Argo updates should be tested on a separate cluster before applying them to prod
 
 Jetstream uses the same tooling and metric versions for an experiment across its entire analysis duration. This prevents inconsistent results, for example, when changes are made to how [mozanalysis] computes results or new default metrics are added in metric-hub mid-experiment.
 
-### Keeping track of tooling versions
+## Keeping Track of Tooling Versions
 
 When a new version of jetstream is released, for example after some library updates, a new Docker container gets pushed to the [Artifact Registry](https://console.cloud.google.com/artifacts?project=moz-fx-data-experiments). The container installs a specific version of each library and can be uniquely identified by a SHA256 hash. A timestamp indicating when the container was uploaded is also available.
 
@@ -116,7 +116,7 @@ Container hashes are passed to the Argo workflow config, which references docker
 
 Jetstream can be run using a specific image version using the `--image_version` parameter. The image can also be changed using the `--image` parameter.
 
-### Keeping track of metric-hub versions
+## Keeping Track of Metric-Hub Versions
 
 Outcome and default configs can potentially change mid-experiment, leaving some experiments in an inconsistent state. Since these configs get pulled in dynamically and aren't installed as part of the Docker image the prior approach doesn't work here.
 

--- a/docs/data-analysis/jetstream/outcomes.md
+++ b/docs/data-analysis/jetstream/outcomes.md
@@ -85,7 +85,7 @@ statistics = { binomial = {} }
 Instruction on how to specify parameter values can be found [Jetstream Configuration](configuration.md#overwriting-outcomes-parameters)
 
 
-## When should I use Outcomes?
+## When Should I Use Outcomes?
 
 As a data scientist, it's useful to define Outcomes whenever an endpoint is going to be used more than once.
 It reduces the amount of work you will need to do for each follow-up experiment and ensures that metrics are defined consistently.
@@ -93,7 +93,7 @@ It reduces the amount of work you will need to do for each follow-up experiment 
 If you're not certain about how you want to define a metric, it's okay to use a custom configuration first,
 and then copy-paste the metrics into an Outcome for later use.
 
-## What happens if an Outcome changes?
+## What Happens if an Outcome Changes?
 
 Changing an Outcome does not re-run any experiments.
 A commit hash associated with the version of each Outcome is captured in the [experiment metadata](./data-products) published to GCS,

--- a/docs/data-analysis/jetstream/statistics.md
+++ b/docs/data-analysis/jetstream/statistics.md
@@ -5,6 +5,10 @@ slug: /data-analysis/jetstream/statistics
 sidebar_position: 3
 ---
 
+Statistics reduce client observations from analysis windows into summarized rows that describe populations, enabling comparisons between experiment branches.
+
+## What Are Statistics?
+
 Statistics reduce observations of many clients
 from a single analysis window
 to one or many rows
@@ -54,7 +58,7 @@ where there's no sensible way to aggregate users that didn't return.
 
 :::
 
-## Available pretreatments
+## Available Pretreatments
 
 Supported pretreatments are listed below. Some pretreatments accept parameters, which are listed below the name of the pretreatment.
 
@@ -66,7 +70,7 @@ Supported pretreatments are listed below. Some pretreatments accept parameters, 
   * `base`: Base of the logarithm. Defaults to 10.0.
 * `zero_fill`: Replace null values in the metric column with zero.
 
-## Available statistics
+## Available Statistics
 
 **Statistics** that Jetstream knows about are listed below. Some statistics accept parameters, which are listed below the name of the statistic.
 
@@ -85,7 +89,7 @@ Supported pretreatments are listed below. Some pretreatments accept parameters, 
   * `gridsize`: Number of samples (default: 256)
   * `log_space`: Whether the KDE should be sampled at geometric (instead of linear) intervals (default: false)
 
-## How do I implement a statistic?
+## How Do I Implement a Statistic?
 
 Statistics are defined in code at https://github.com/mozilla/jetstream/blob/main/jetstream/statistics.py.
 

--- a/docs/data-analysis/jetstream/testing.md
+++ b/docs/data-analysis/jetstream/testing.md
@@ -5,7 +5,7 @@ slug: /data-analysis/jetstream/testing
 sidebar_position: 9
 ---
 
-# Testing Jetstream Configs
+Jetstream configurations can be validated through CI checks, local validation, or by generating previews to verify metrics before deploying to production experiments.
 
 ## Validation via Continuous Integration (CI)
 
@@ -13,7 +13,7 @@ Configurations for Jetstream experiments get added by opening a pull-request in 
 
 Pull-requests that pass the CI validation can be automatically merged without requiring an external review.
 
-## Local validation
+## Local Validation
 
 To locally iterate and validate Jetstream configurations, the Jetstream tooling needs to be installed: 
 
@@ -33,7 +33,7 @@ In case changes have been made to outcomes, defaults or metric definitions it is
 jetstream validate_config /local/path/to/config/file.toml --config_repos=/path/to/metric-hub
 ```
 
-## Jetstream previews
+## Jetstream Previews
 
 When iterating on configurations, it is sometimes useful to get a preview of what computed data on the final dashboard would look like. Previews are computed on a data sample in order to reduce cost and speed up the analysis. Preview data should not be used to draw any conclusions on the outcome of an experiment. It should only be used to validate configurations.
 

--- a/docs/data-analysis/jetstream/troubleshooting.md
+++ b/docs/data-analysis/jetstream/troubleshooting.md
@@ -5,7 +5,7 @@ slug: /data-analysis/jetstream/troubleshooting
 sidebar_position: 8
 ---
 
-### How can I see what Jetstream is doing? 
+### How Can I See What Jetstream Is Doing? 
 
 For checking on daily Jetstream runs, the `jetstream` DAG can be viewed via the [Airflow Web UI](https://workflow.telemetry.mozilla.org/tree?dag_id=jetstream). This show whether the run is still in progress or has completed.
 
@@ -19,7 +19,7 @@ gcloud container clusters get-credentials jetstream --zone us-central1-a --proje
 
 The dashboard can than be accessed via [127.0.0.1:8080](http://127.0.0.1:8080) through the web browser and provides a detailed overview of past workflows, the statuses of each step in a workflow and container logs.
 
-### How do I know if something went wrong?
+### How Do I Know if Something Went Wrong?
 
 Jetstream logs errors to the console and, optionally, to the `monitoring.logs` BigQuery table. Logging to BigQuery is enabled by default when running Jetstream via Airflow, as it allows for better alerting and monitoring of errors. It is by default disabled for runs triggered via the metric-hub CI.
 
@@ -27,7 +27,7 @@ Errors can be viewed on the [Jetstream error dashboard] in Looker.
 
 Additionally, alerts can be set up in Looker to check for errors daily and sent an email if failures have been detected. To subscribe to these alerts, go to the [Jetstream error dashboard], click on the _Alerts_ (bell) icon on the _Critical Errors Last Run_ tiles and follow the "Error Count" alert.
 
-### Something went wrong, what do I do?
+### Something Went Wrong, What Do I Do?
 
 1. Check the [Jetstream error dashboard] for more details on the error that occurred.
 1. If the experiment uses a custom configuration, make sure the configuration is valid. Sometimes, SQL written for specifying metrics in the configuration file can contain logical errors that result in failures when computing statistics.
@@ -35,7 +35,7 @@ Additionally, alerts can be set up in Looker to check for errors daily and sent 
 
 If you are unsure of what might have gone wrong or what to, you can open [an issue in Jira](https://jira.mozilla.com/projects/CIRRUS/issues/CIRRUS-68?filter=allopenissues) or ask for help in the [#ask-experimenter](https://mozilla.slack.com/archives/CF94YGE03) Slack channel.
 
-### Some results appear to be missing
+### Some Results Appear to Be Missing
 
 It can take up to 2 days for results of the overall time period to be available after an experiment ends. For example, if an experiment ends on 2021-04-05, then results for the overall time period will be computed in the next daily analysis run on 2021-04-06. As running the analysis can take a few hours to complete results will be available on 2021-04-07.
 
@@ -43,7 +43,7 @@ If results other than for the overall period are missing or more than 2 days hav
 
 If there have been no errors, or the errors cannot be resolved, open [an issue in Jira](https://jira.mozilla.com/projects/CIRRUS/issues/CIRRUS-68?filter=allopenissues) or ask for help in the [#ask-experimenter](https://mozilla.slack.com/archives/CF94YGE03) Slack channel.
 
-### How do I debug operational or more complex errors?
+### How Do I Debug Operational or More Complex Errors?
 
 Debugging operational or more complex errors is usually done by Jetstream engineers.
 
@@ -53,26 +53,26 @@ Debugging operational or more complex errors is usually done by Jetstream engine
 
 The logs can indicate a couple of different problems:
 
-#### There has been a operational error related to Kubernetes
+#### There Has Been an Operational Error Related to Kubernetes
 
 This could happen, for example, if available memory or CPUs have been exceeded. To get more information about the pods that failed, navigate to the [`jetstream` Kubernetes cluster in the GCP web console](https://console.cloud.google.com/kubernetes/workload?project=moz-fx-data-experiments&pageState=(%22savedViews%22:(%22i%22:%22bf4f1f5805924fe2ba1cd23bd3b0ef8b%22,%22c%22:%5B%22gke%2Fus-central1-a%2Fjetstream%22%5D,%22n%22:%5B%5D))). The web UI allows to view the memory and CPU usage of specific pods or the entire cluster as well as pod logs. This information can help to decide whether the cluster needs to be resized. Resizing the cluster or allocating more resources is worth considering if these errors happen frequently. For occasional failures, simply rerunning the affected experiment is sufficient.
 
-#### An external config or outcome definition is causing failures
+## An External Config or Outcome Definition Is Causing Failures
 
 1. Ensure that the config is valid and that SQL does not contain any logical errors.
 1. If the SQL has become too complex, try to simplify queries or use source tables instead of derived views.
 1. Fix the configuration. Once the new config gets merge, the experiment will be rerun automatically.
         
-#### There has been an error because of a timeout when using an external API.
+## There Has Been an Error Because of a Timeout When Using an External API
 
 Timeouts occasionally happen when running queries in BigQuery, fetching experiments from the Experimenter API or fetching config files from GitHub. Jetstream implements a retry mechanism for most of these cases but it is possible that all of these retries fail. Rerunning affected experiments should in most cases resolve these issues. However, if this failures keep happening then this could indicate API changes.
         
-#### There is a bug in the jetstream code base
+## There Is a Bug in the Jetstream Code Base
 1. Add a test case to [jetstream] to reproduce the error.
 1. Fix the bug and open a PR against the repository.
 1. Once the fix has been approved, merged and deployed, the affected experiment can be rerun.
 
-#### Airflow returned an error or is sending notification emails
+## Airflow Returned an Error or Is Sending Notification Emails
 
 1. Check the Airflow logs
 1. Errors in Airflow can happen if there has been a problem with the Airflow cluster itself, e.g. the jetstream tasks could not be started. In this case, clearing the affected task to trigger a rerun should fix the issue. If problems persist, then reach out to data ops by [opening a Bugzilla ticket](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data%20Platform%20and%20Tools).

--- a/docs/data-analysis/telemetry.md
+++ b/docs/data-analysis/telemetry.md
@@ -4,6 +4,8 @@ title: Telemetry
 slug: /data-analysis/telemetry
 ---
 
+Nimbus telemetry provides standard events and experiment annotations used to track enrollment, exposure, and unenrollment throughout an experiment's lifecycle.
+
 This section is an overview of Nimbus Telemetry intended for the analysis of experiments.
 
 ## Standard Events

--- a/docs/data-analysis/validating-experiments.md
+++ b/docs/data-analysis/validating-experiments.md
@@ -4,11 +4,13 @@ title: Validation
 slug: /data-analysis/validating-experiments
 ---
 
+This guide describes common experiment problems to watch for, including branch imbalance, low enrollments, and high unenrollments, along with recommended testing approaches and potential causes.
+
 This section describes some common problems with experiments that you should look out for, how we recommend testing for them, and some potential causes to investigate if you do see that something is wrong.
 
 You should consider this a starting point, not a comprehensive list. **Generally speaking, interesting results warrant a higher degree of scrutiny**.
 
-### Branch imbalance (Sample Ratio Mismatch)
+## Branch Imbalance (Sample Ratio Mismatch)
 
 We expect to see some variation between the observed v.s. expected ratios for enrollment in branches for experiments. However, too much imbalance might be indication that there might be a problem with the validity of the experiment configuration, implementation, or execution.
 
@@ -26,7 +28,7 @@ You will see SRM checks for daily active clients, enrollments, and unenrollments
 - High unenrollments in treatment due to implementation details of the experience being tested
 - Irregularities in deployment of experiments/updating in flight
 
-### Low enrollments
+## Low Enrollments
 
 Once your experiment has been enrolling for a day or so, you should check your monitoring dashboards to see the difference between the actual and expected rate of enrollment. If numbers are lower than expected, this can be due to:
 
@@ -37,7 +39,7 @@ Once your experiment has been enrolling for a day or so, you should check your m
 - A bug, timeout, or implementation error in client-side targeting attributes;
 - You launched the experiment during the first week of a new release, during which actual users are still updating to the latest version of Firefox
 
-### High unenrollments
+## High Unenrollments
 
 Users can be removed from experiments for a number of reasons, which shows up on your dashboard as "unenrollments". When unenrollments look suspiciously high, these are some possible causes to investigate:
 
@@ -46,7 +48,7 @@ Users can be removed from experiments for a number of reasons, which shows up on
 - Infrastructure failures (e.g. signing, remote settings delivery is somehow compromised)
 - Users are opting out of the experiment at an unexpected rate
 
-#### Debugging unenrollments by reason
+### Debugging Unenrollments by Reason
 
 In order to see which "reasons" are responsible for unenrollment, you can take a look at this part of the dashboard:
 ![image](https://user-images.githubusercontent.com/1455535/137957335-e34e9ab5-05cd-42b2-b1fd-2e88d90bb60c.png)


### PR DESCRIPTION
Because

* Documentation articles had inconsistent formatting

This commit

* Adds consistent summary and heading structure to Data & Analysis articles

fixes #747