### PR TITLE
chore: consistent formatting for getting started

### DIFF
--- a/docs/getting-started/contributing.md
+++ b/docs/getting-started/contributing.md
@@ -1,7 +1,7 @@
 ---
-id: contributing
-title: Contributing
-slug: /contributing
+id: for-contributors
+title: For Contributors
+slug: /getting-started/for-contributors
 ---
 
 The Experimenter documentation hub is managed in the [mozilla/experimenter-docs](https://github.com/mozilla/experimenter-docs) repository. You will need a GitHub account to contribute, and if you are not already in the [Project Nimbus GitHub team](https://github.com/orgs/mozilla/teams/project-nimbus/members), you may need to request write access in the #nimbus-project Slack channel.
@@ -21,7 +21,7 @@ If you need custom CSS styles, you can edit the `src/css/custom.css` file. Try t
 <div className="flex-lg">
 <div>
 
-### Configuring Your Notifications
+## Configuring Your Notifications
 
 If you would like to subscribe to notifications for this repository, including for when someone requests doc changes with a pull request that you can potentially review and approve, be sure to "Watch" the repository by clicking on the repository's "Notification settings" menu and selecting "All Activity."
 
@@ -55,7 +55,7 @@ When you're satisfied with your changes or new document, at the bottom of the pa
 
 Click `Commit changes` and you'll be brought to a pull request view comparing your new branch to `main`. If you don't need to make updates to the sidebar, see the [Pull Request Workflow](#pull-request-workflow) section and click `Create pull request`.
 
-#### Doc Edits + Sidebar Edits
+### Doc Edits + Sidebar Edits
 
 If you also need to make updates to the sidebar, you will follow the GH UI link under "Adding or Modifying Sidebar Links" but replace "main" in the URL with the name of your branch. For example, if the name of your branch is `my-flying-nimbus`, [this would be the link](https://github.com/mozilla/experimenter-docs/edit/my-flying-nimbus/sidebars.js) you'd use to edit that file. Similarly to the instructions above, after you've made the desire changes, enter a commit message and optional description. However, this time, you will select the option **commit directly to the `my-flying-nimbus` branch** instead of creating a new branch.
 
@@ -63,7 +63,7 @@ After committing your changes, you'll be brought back to a pull request view com
 
 ### Pull Request Workflow
 
-#### PR Template
+### PR Template
 
 After clicking `Create pull request`, you will be presented with a pull request template specific to this repository.
 
@@ -71,7 +71,7 @@ Edit the line `Closes: mozilla/experimenter#0000` where `experimenter` may need 
 
 Under "Permission Checklist," check the boxes applicable to your pull request that would make this process easier for you. If you have any specific requests regarding the checkboxes or anything else, please note them in the pull request.
 
-#### Reviewing and Merging
+### Reviewing and Merging
 
 To make sure your pull request is reviewed, either request a specific reviewer to look at your PR, request the `mozilla/project-nimbus-team`, or ask the team in the #nimbus-project Slack channel to take a look. Once you've created the pull request, automatic checks will run to ensure the project can build and deploy successfully with your changes, and at least one reviewer will need to approve your PR.
 

--- a/docs/getting-started/for-data-scientists.md
+++ b/docs/getting-started/for-data-scientists.md
@@ -1,7 +1,7 @@
 ---
-id: overview
+id: for-data-scientists
 title: For Data Scientists
-slug: /overview
+slug: /getting-started/for-data-scientists
 sidebar_position: 1
 ---
 
@@ -11,18 +11,18 @@ Some other things you may be looking for are:
 
 * Documentation about using [Jetstream](/data-analysis/jetstream/overview), Mozilla's experiment analysis tool
 * Technical documentation about [datasets used in experimentation](https://docs.telemetry.mozilla.org/tools/experiments.html)
-* [Process documentation](https://experimenter.info/for-product) for the Mozilla data science organization
+* [Process documentation](https://experimenter.info/getting-started/for-experiment-owners) for the Mozilla data science organization
 
-## What is the role of experimentation at Mozilla?
+## What Is the Role of Experimentation at Mozilla?
 
 Experimentation informs product decision-making at Mozilla.
 This suite of experimentation tools is designed for product managers and other investigation owners to A/B test hypotheses they have about new and existing products and features.
 [Experimenter](https://experimenter.services.mozilla.com/nimbus/) (internal link) contains examples of completed and active experiments.
 
-## Collaborating with experiment owners
+## Collaborating with Experiment Owners
 
 Data scientists support experiment owners in setting up and interpreting their experiments.
-[The Firefox experiment design process](https://experimenter.info/for-product) describes the process for both data scientists and stakeholders.
+[The Firefox experiment design process](https://experimenter.info/getting-started/for-experiment-owners) describes the process for both data scientists and stakeholders.
 
 Experiment owners come to [Office Hours](https://docs.google.com/document/d/1dH-aG8IsYtq6881_Q_cyEtmxli0bK7nuVcUD-5D7q-s/edit#) to talk to data scientists to:
 
@@ -34,7 +34,7 @@ Experiment owners come to [Office Hours](https://docs.google.com/document/d/1dH-
 If there is follow work needed outside of office hours, a Data Org Jira ticket is filed.  Example:
 * writing [custom metrics](/data-analysis/jetstream/metrics) if needed
 
-## Sampling framework
+## Sampling Framework
 
 Each experiment begins with an enrollment period with fixed start and end dates during which clients can enroll in the experiment. After the declared enrollment period ends, we modify the recipe to instruct clients to stop enrolling, and ignore clients that report enrollment anyway. Because enrollment depends on the client checking for software updates, samples will be skewed towards active users at the beginning of the enrollment period. We typically leave enrollment open for a week to account for weekly seasonality (e.g. weekday vs. weekend users) and to give clients who are active less often a chance to enroll. This makes our experiment population essentially a sample of the weekly active users (WAU).
 
@@ -42,7 +42,7 @@ For each client, experiment metrics are analyzed over a defined period of time f
 
 For more nuances about sampling, enrollment and exposure (whether or not the client actually saw the treatment or control), see [the experiment lifecycle overview](/technical-reference/client-sdk-lifecycle).
 
-## Sample size recommendations
+## Sample Size Recommendations
 
 Sample size recommendations the fraction of the Firefox population that should be enrolled in your recipe.  This is determined by discussing your [experiment design document](https://docs.google.com/document/d/1_bWn_1y5x1zf6zl7Loj4O1qKnVdxzIMXOawIpf32CsM/edit?tab=t.0) at [Data science office hours](https://docs.google.com/document/d/1dH-aG8IsYtq6881_Q_cyEtmxli0bK7nuVcUD-5D7q-s/edit#).
 
@@ -64,7 +64,7 @@ You must inflate your population fraction to account for filtering.
 
 For a concrete example, imagine that Firefox WAU is 1,000 clients. 20% of WAU is from Canada. You wish to deploy an experiment to Canadian users. Your power analysis says that you need 50 clients in total to enroll. You should specify a population fraction of at least 25%, because 1,000 \* 0.2 (from Canada) \* 0.25 (your filter) = 50.
 
-### Multiple experiments on the same feature
+### Multiple Experiments on the Same Feature
 If there are already Live experiments on the same feature as your experiment, you **sometimes** need to inflate the sample size to account for clients enrolled in the existing Live experiments that the Nimbus front-end is not aware of. Instructions below.
 
 1. Find the most recent experiment that launched for your feature on your channel.
@@ -81,13 +81,13 @@ If there are already Live experiments on the same feature as your experiment, yo
 3. The example JSON above shows that the most recent experiment used buckets 3678 to 7156 (= 3678 + 3478). If your new experiment needs less than 28.44% (= (10,000 - 7156)/100) of the clients, then you do not need to inflate the percentage to account for Nimbus being unaware of clients enrolled in previous experiments.
 4. If your new experiment needs more than 28.44% of the clients, then you must inflate the percentage to account for 71.56% of the clients already being enrolled in experiments. For example, if your new experiment needs 30% of the clients, then you must input 41.92% (= 30% / 71.56%) into "Population %" in the Nimbus front-end.
 
-### Non-normal distributions
+### Non-Normal Distributions
 Most of our telemetry metrics are not normally distributed. A couple approaches that you may find helpful are:
 
 * powering a Mann-Whitney U-test. [Gpower](https://www.psychologie.hhu.de/arbeitsgruppen/allgemeine-psychologie-und-arbeitspsychologie/gpower) implements the Mann-Whitney U-test.
 * log-transforming the data and the expected difference and powering a _t_ test in log space.
 
-## Metrics and statistics
+## Metrics and Statistics
 
 Two weeks after the beginning of the enrollment period, Jetstream will begin to produce auto-generated reports summarizing the results of the experiment. [Here is one such report](https://experimenter.services.mozilla.com/nimbus/custom-messaging-in-aboutwelcome-for-chrome-users-to-import/results) (internal link).
 
@@ -97,7 +97,7 @@ If you want to perform some analysis by hand, [Jetstream datasets](https://docs.
 
 For certain experiments, data scientists may need to construct confidence intervals for relative or percent differences. Example implementations can be found in [this notebook](https://colab.research.google.com/drive/1sVOdVdraPwec_Hit4OiaDDH4TJGzaIcc?usp=sharing).
 
-## Watch out for
+## Watch Out For
 
 Here are other things to watch out for:
 - Are there other experiments taking place at the same time as yours? How might that affect the interpretation of your results, or limit your sample sizes?

--- a/docs/getting-started/for-engineers.md
+++ b/docs/getting-started/for-engineers.md
@@ -1,19 +1,19 @@
 ---
 id: for-engineers
-title: For Engineers 
-slug: for-engineers
+title: For Engineers
+slug: /getting-started/for-engineers
 ---
 
 Engineers are typically tasked with implementing an experiment on a new surface with an experiment that has been designed by their product manager in partnership with a data scientist.
 
-## Integrating with a new app
+## Integrating with a New App
 
 * [Getting started with Nimbus, for Android Engineers](/platform-guides/android/integration)
 * [Getting started with Nimbus for iOS Engineers](/platform-guides/ios/integration)
 * [Getting Started for Nimbus Web Integration](platform-guides/web/integration)
 * [Mobile UI needed for Nimbus](/platform-guides/android/mobile-ui)
 
-## To get started with implementation
+## To Get Started with Implementation
 
 * Review the experiment design document.
 * Determine if you need to implement any additional telemetry collection

--- a/docs/getting-started/for-experiment-owners.md
+++ b/docs/getting-started/for-experiment-owners.md
@@ -1,10 +1,12 @@
 ---
-id: for-product
-title: Experiment Owners
-slug: /for-product
+id: for-experiment-owners
+title: For Experiment Owners
+slug: /getting-started/for-experiment-owners
 ---
 
-## What is the role of the Experiment Owner in experimentation?
+This guide helps experiment owners (typically Product Managers) understand their role in the experimentation process, from creating experiment briefs to launching and analyzing experiments.
+
+## What Is the Role of the Experiment Owner in Experimentation?
 
 Product Managers often write the initial experiment to capture the logistical information, but it can also be engineers or program managers.  Often engineers fill in the technical change information - so ownership can be a collaboration to get the logistical and technical information for the remote change entered correctly.
 
@@ -19,7 +21,7 @@ Responsibilities include:
 - Launching the experiment, ending enrollment, ending experiment (the [experimentation workflow](/workflow/overview))
 - Working with the experiment team (in slack at #ask-experimenter) to identify a set of reviewers trained and authorized to review experiments in your feature area. The experiment team will train them on how to review.
 
-## Where do I start?
+## Where Do I Start?
 
 - Watch the 5 minute video on [experiment workflow](https://experimenter.info/workflow/overview) for an overview of the experiment lifecycle to understand the stages / ordering. Use the [Workflow Miro board](https://experimenter.info/workflow/overview) as your source for current links and guidance.
 
@@ -46,7 +48,7 @@ Rather than duplicate links that may later break as the process improves - links
 - There are several weekly touchpoints [Office Hours](https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/6849684/Office+Hours) for in person assistance from subject matter experts in different areas.
 - If you are confused on any aspect - that's expected the first few experiments until you've gotten the rhythm. Ask in the #ask-experimenter Slack channel - it is an open community of support from several disciplines.
 
-## When shipping product changes: a guide on when to use what option
+## When Shipping Product Changes: A Guide on When to Use What Option
 
 |                                                           |                                                                     Experiment (Experimentation Program)                                                                      |                                                         Rollout                                                         |                                                                Holdback                                                                |
 | --------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------------------------------------: |
@@ -59,7 +61,7 @@ Rather than duplicate links that may later break as the process improves - links
 | Advantages                                                |                                                          Can measure impact first, then if positive ship the change                                                           |                                           Can scale up or down as appropriate                                           |                                              Faster than blocking on impact measurements                                               |
 | Experiment brief needed                                   |                                                                                      Yes                                                                                      |                                                           No                                                            |                                                                  Yes                                                                   |
 
-## Example of how to construct a balanced launch plan
+## Example of How to Construct a Balanced Launch Plan
 
 [What Velocity team practices today]
 

--- a/docs/getting-started/for-leadership.md
+++ b/docs/getting-started/for-leadership.md
@@ -1,10 +1,12 @@
 ---
 id: for-leadership
 title: For Leadership
-slug: /for-leadership
+slug: /getting-started/for-leadership
 ---
 
-## How can leadership interact with experiments?
+This guide provides leadership with an overview of how to monitor experiments, access results, and track the experimentation program's progress across teams.
+
+## How Can Leadership Interact with Experiments?
 *  [Nimbus Console](https://experimenter.services.mozilla.com/nimbus/) is the best place for exploring what is running, completed, and in draft.  Currently there is basic filtering - which will be expanded this year to enable easier experiment discovery.
 *  Each experiment should have an Experiment Brief following this [template](https://docs.google.com/document/d/1eFGL9FATIuZudjSItpIT2Ct1C5qb5E3Qk7hJuJQT67s/edit#), as a link from Nimbus Console - which goes into the background, learning goals, and experiment design.
 *  After an experiment is completed, there is a Results link in the right hand vertical gray bar.  ![image](https://user-images.githubusercontent.com/8192232/171439876-33124105-514b-40ec-8edc-cfa4fd681ffb.png)
@@ -12,7 +14,7 @@ slug: /for-leadership
 *  For completed experiments, there should be information added to Nimbus Console in the "Takeaways" section for a high level tl;dr interpretations and actions taken for each experiment.  If that is blank - ask the Product Manager for the takeaways and learnings and to fill that section. ![image](https://user-images.githubusercontent.com/8192232/171439992-3bb9c53d-0595-40d9-99ee-7b20d5e3f5b7.png)
 
 
-## Where do I find Experimentation Program metrics?
+## Where Do I Find Experimentation Program Metrics?
 The [Experiment Tracking spreadsheet](https://docs.google.com/spreadsheets/d/1oEvS0CI52kod7i-prk8rnVPr_6Nk19QSBVHAvxmVRgI/edit?gid=408542968#gid=408542968) is the current source of truth on experimentation program metrics.
 *  This is updated monthly before Product Days
 *  The summary view has the SPI metrics that are being reported out regularly.

--- a/docs/getting-started/for-reviewers.md
+++ b/docs/getting-started/for-reviewers.md
@@ -1,21 +1,22 @@
 ---
-title: Access & Reviewers
-slug: /access
+id: for-reviewers
+title: For Reviewers
+slug: /getting-started/for-reviewers
 ---
 
 With Nimbus experiments, instead of a centralized committee responsible for launching and running experiments **we want you, the experiment owner, to drive the process from ideation to completion**.
 
 If you are interested in learning more about your responsibilities, you can find our complete [Access Control Policy here](https://docs.google.com/document/d/1r8oI_Hxe5JQcOejqZcSziX1Aso20AFGBToTFu3BE5j8/edit).
 
-### Onboarding for New Authors/Owners (L2)
+## Onboarding for New Authors/Owners (L2)
 
-In order to use the Nimbus platform to create and launch experiments, you will need to go through the [Experiment Owner onboarding process](https://experimenter.info/for-product). Please ask in [#ask-experimenter](https://mozilla.slack.com/archives/CF94YGE03) if you have any questions and for a shadow on the first experiments(s) you create.
+In order to use the Nimbus platform to create and launch experiments, you will need to go through the [Experiment Owner onboarding process](https://experimenter.info/getting-started/for-experiment-owners). Please ask in [#ask-experimenter](https://mozilla.slack.com/archives/CF94YGE03) if you have any questions and for a shadow on the first experiments(s) you create.
 
-### Onboarding for New Reviewers (L3)
+## Onboarding for New Reviewers (L3)
 
 Assuming you have been vouched for by a Nimbus administrator + a Product Owner (product manager or engineering manager if the team doesn’t have a dedicated PM), you should go through the following steps to get review access on Nimbus:
 
-#### Basic access
+### Basic Access
 
 - Read through [rules and responsibilities for L3 users](https://docs.google.com/document/d/1r8oI_Hxe5JQcOejqZcSziX1Aso20AFGBToTFu3BE5j8/edit#heading=h.6v62tolv8dnv). Please note that you will have access to making changes in production for all experiments, and you should decline if you don't feel sufficiently qualified to review an experiment
 - Watch the half hour [reviewer training video](https://mozilla.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=b2608de6-defe-44e4-9517-af5d0035268c).  The [training slides are here](https://docs.google.com/presentation/d/11jGYVCRhzqG5R4aemcNtfQ3umzsQAcZrGiFp5a9T7us/edit#slide=id.g144dc03564c_0_7) for reference and links.
@@ -23,7 +24,7 @@ Assuming you have been vouched for by a Nimbus administrator + a Product Owner (
 - [File a bug using this template](https://bugzilla.mozilla.org/enter_bug.cgi?product=Cloud%20Services&component=Server%3A%20Remote%20Settings) to be added to either or all of the following collections: `nimbus-desktop-experiments` and/or `nimbus-mobile-experiments` and/or `nimbus-web-experiments` for your LDAP to be added on staging and production.
 - Note: on your first review(s) - please ask in #ask-experimenter for a shadow. It's very easy to partner with you sharing a screen to make sure you don't have any questions or uncertainties.
 
-#### Testing Review Workflow on Staging
+### Testing Review Workflow on Staging
 
 - Connect to the VPN
 - Go to [Nimbus Staging](https://stage.experimenter.nonprod.webservices.mozgcp.net/nimbus/) (not Production!). Ask someone to create a dummy experiment and request review.
@@ -36,6 +37,6 @@ Assuming you have been vouched for by a Nimbus administrator + a Product Owner (
 - Press approve if everything looks good. If anything looks wrong, Reject and alert nimbus core team in #ask-experiments
 - Congrats, you have tested the workflow. You are now ready to review real experiments on production!
 
-### Reviews
+## Reviews
 
 All changes to experiments and rollouts that impact production must be approved by a single L3 Nimbus reviewer, which you can request via the Nimbus console interface. *The requester and reviewer must be different people.*  You can find a list of [recommended reviewers here](https://mozilla-hub.atlassian.net/wiki/spaces/FJT/pages/11470672/Nimbus+Reviewers).

--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -25,7 +25,7 @@ slug: /glossary
 **Custom targeting**: coming soon
    * [Targeting attributes](https://firefox-source-docs.mozilla.org/browser/components/asrouter/docs/targeting-attributes.html)
    * [Mobile messaging behavioral targeting](/advanced/behavioral-targeting)
-   * See also: "Targeting Considerations" on the Nimbus Experiment Brief template available [here](/for-product#where-do-i-start)
+   * See also: "Targeting Considerations" on the Nimbus Experiment Brief template available [here](/getting-started/for-experiment-owners#where-do-i-start)
 
 ----
 

--- a/docs/homepage/welcome.md
+++ b/docs/homepage/welcome.md
@@ -32,7 +32,7 @@ Nimbus is a full-featured experimentation platform that provides configuration, 
 - [Advanced customizable targeting](/advanced/custom-audiences)
 - [Adding Metrics to your Experiment](/data-analysis/jetstream/metrics)
 - [Remote settings integration](/advanced/rollouts)
-- [Experiment Review / Approval Workflow](/access)
+- [Experiment Review / Approval Workflow](/getting-started/for-reviewers)
 - [Dashboards](/monitoring)
 - [Monitoring and Analysis](/data-analysis/jetstream/overview)
 
@@ -81,4 +81,4 @@ If you aren't sure we have what you need, pop into #ask-experimenter with your q
 
 ## About these docs
 
-This website is built using [Docusaurus](https://v2.docusaurus.io/). If you'd like to edit or add to them, check out the [Contributing](/contributing) page.
+This website is built using [Docusaurus](https://v2.docusaurus.io/). If you'd like to edit or add to them, check out the [Contributing](/getting-started/for-contributors) page.

--- a/docs/messaging/mobile-surveys.md
+++ b/docs/messaging/mobile-surveys.md
@@ -58,7 +58,7 @@ Note that this calculation was done for a single survey branch. If you're runnin
 
 ## Configure in Nimbus
 
-Prerequisite: at least one person on the team will have to have gone through [experiment owner training](/access#onboarding-for-new-authorsowners-l2).
+Prerequisite: at least one person on the team will have to have gone through [experiment owner training](/getting-started/for-reviewers#onboarding-for-new-authorsowners-l2).
 
 If you want to run surveys both on Android and iOS, you'll need to configure a separate delivery for each one as deliveries are client-specific.
 
@@ -112,7 +112,7 @@ See below for an example (from the Viewpoint survey):
 
 ## Launch
 
-Once QA is complete, the survey can be launched. The survey owner should request to launch and then post a message in [#ask-experimenter](https://mozilla.slack.com/archives/CF94YGE03) asking for an approver. As of the time of writing these docs, Rosanne Scholl & Daniel Berry are qualified reviewers for mobile surveys. If your team plans to run many surveys, it's recommended to have some members go through [reviewer training](/access#onboarding-for-new-reviewers-l3) so that the team can self-review their configurations without having to wait on external reviewers. Again, reach out in [#ask-experimenter](https://mozilla.slack.com/archives/CF94YGE03) for help with this.
+Once QA is complete, the survey can be launched. The survey owner should request to launch and then post a message in [#ask-experimenter](https://mozilla.slack.com/archives/CF94YGE03) asking for an approver. As of the time of writing these docs, Rosanne Scholl & Daniel Berry are qualified reviewers for mobile surveys. If your team plans to run many surveys, it's recommended to have some members go through [reviewer training](/getting-started/for-reviewers#onboarding-for-new-reviewers-l3) so that the team can self-review their configurations without having to wait on external reviewers. Again, reach out in [#ask-experimenter](https://mozilla.slack.com/archives/CF94YGE03) for help with this.
 
 ## End
 

--- a/docs/workflow/ending/ending.md
+++ b/docs/workflow/ending/ending.md
@@ -22,7 +22,7 @@ Some notes:
 enrollment_period = 14
 ```
 
-Once the experiment has reached the end of the enrollment period, the experiment owner can elect to end enrollment which will prevent new clients from enrolling. To do this, first press the `End Enrollment` button located on the experiment's management page in [the Experimenter console](https://experimenter.services.mozilla.com). This will record the request. A reviewer with [L3 access](/access) *will then need to approve the request*. If your product team does not have a dedicated reviewer, you can request the ending by posting in [#ask-experimenter](https://mozilla.slack.com/archives/CF94YGE03).
+Once the experiment has reached the end of the enrollment period, the experiment owner can elect to end enrollment which will prevent new clients from enrolling. To do this, first press the `End Enrollment` button located on the experiment's management page in [the Experimenter console](https://experimenter.services.mozilla.com). This will record the request. A reviewer with [L3 access](/getting-started/for-reviewers) *will then need to approve the request*. If your product team does not have a dedicated reviewer, you can request the ending by posting in [#ask-experimenter](https://mozilla.slack.com/archives/CF94YGE03).
 
 <p align="center">
     <img src="/img/workflow/end_enrollment.png"></img>

--- a/docs/workflow/implementing/experiment-owners.md
+++ b/docs/workflow/implementing/experiment-owners.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 For an overview of experiment lifecycle, [ See Experiment Workflow Overview ](https://experimenter.info/workflow/overview/#experimentation-workflow)
 
-After you've prepared your experiment brief, entering the info into the [Nimbus/experimenter console](https://experimenter.services.mozilla.com/) should not take a long time. The role of experiment owner is most frequently played by a Product Manager, though others may act in this capacity.  Please follow the [Getting Started: Product Manager guidance](/for-product) before using Nimbus/experimenter for the first time.  If it is your first time - feel free to ask for a "shadow" in #ask-experimenter.  A "shadow" is an experienced experiment buddy to answer questions on zoom while you fill out your first experimenter form.
+After you've prepared your experiment brief, entering the info into the [Nimbus/experimenter console](https://experimenter.services.mozilla.com/) should not take a long time. The role of experiment owner is most frequently played by a Product Manager, though others may act in this capacity.  Please follow the [Getting Started: Product Manager guidance](/getting-started/for-experiment-owners) before using Nimbus/experimenter for the first time.  If it is your first time - feel free to ask for a "shadow" in #ask-experimenter.  A "shadow" is an experienced experiment buddy to answer questions on zoom while you fill out your first experimenter form.
 
 Experimenter is intended to be flexible and simple to use by allowing users to:
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -12,13 +12,12 @@ module.exports = {
       type: "category",
       label: "Getting Started",
       items: [
-        "getting-started/for-product",
-        "workflow/implementing/experiment-owners",
-        "getting-started/data-scientists/overview",
-        "getting-started/engineers/for-engineers",
-        "getting-started/access",
+        "getting-started/for-experiment-owners",
+        "getting-started/for-data-scientists",
+        "getting-started/for-engineers",
+        "getting-started/for-reviewers",
         "getting-started/for-leadership",
-        "getting-started/contributing"
+        "getting-started/for-contributors"
       ]
     },
 
@@ -30,6 +29,7 @@ module.exports = {
       label: "Experiment Workflow",
       items: [
         "workflow/overview",
+        "workflow/implementing/experiment-owners",
         {
           type: "category",
           label: "Designing",
@@ -60,7 +60,17 @@ module.exports = {
         "workflow/launching/launching",
         "workflow/monitoring/monitoring",
         "workflow/analyzing/analyzing",
-        "workflow/ending/ending"
+        "workflow/ending/ending",
+        {
+          type: "link",
+          label: "Experimenter Console (Production)",
+          href: "https://experimenter.services.mozilla.com/nimbus/"
+        },
+        {
+          type: "link",
+          label: "Experimenter Console (Stage)",
+          href: "https://stage.experimenter.nonprod.webservices.mozgcp.net/nimbus/"
+        }
       ]
     },
 
@@ -321,16 +331,6 @@ module.exports = {
       type: "category",
       label: "External Links",
       items: [
-        {
-          type: "link",
-          label: "Experimenter Console (Production)",
-          href: "https://experimenter.services.mozilla.com/nimbus/"
-        },
-        {
-          type: "link",
-          label: "Experimenter Console (Stage)",
-          href: "https://stage.experimenter.nonprod.webservices.mozgcp.net/nimbus/"
-        },
         {
           type: "link",
           label: "Experimenter GitHub Repo",


### PR DESCRIPTION
Because
    
* We have good articles in the getting started section
* Navigation is smoother with consistent use of headers
* Searching is easier with short summaries
    
This commit
    
* Renames all the getting started articles into their target audience
* Adds a short summary to articles missing them
* Updates headers to use consistent nesting
* Moves Experiment Console down into workflow
    
fixes #744