### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @b4handjr @freshstrangemusic @jaredlockhart @jeddai @mikewilli @yashikakhurana
+* @freshstrangemusic @jaredlockhart @mikewilli @yashikakhurana @relud


### PR DESCRIPTION
Becuase

* We haven't updated codeowners in a while

This commit

* Updates codeowners to show the current team members

fixes #767

