### PR TITLE
chore: consistent formatting for platform guides

### DIFF
--- a/docs/platform-guides/android/custom-targeting.md
+++ b/docs/platform-guides/android/custom-targeting.md
@@ -1,6 +1,6 @@
 ---
 id: android-custom-targeting
-title: Android
+title: Custom Targeting
 slug: /platform-guides/android/custom-targeting
 ---
 
@@ -8,18 +8,18 @@ slug: /platform-guides/android/custom-targeting
 **This method of adding new targeting attributes is deprecated. Please use the method described in the [Recorded Targeting Context doc](/advanced/recording-targeting-context#adding-new-fields).**
 :::
 
-# Adding new targeting attributes to Android
+## Adding New Targeting Attributes to Android
 This page demonstrates how to add new targeting attributes to Android, enabling experiment creators more specific targeting.
 For more general documentation on targeting custom audiences, check out [the custom audiences docs](/advanced/custom-audiences)
 
-## Adding the attribute to the application
+## Adding the Attribute to the Application
 The Nimbus SDK exposes a new `customTargetingAttributes` parameter in its initializer that is a `Map<String, String>` map. We can take advantage of this parameter to pass in new targeting attributes without modifying the Nimbus SDK at all.
 :::warning
 A current limitation is that both the key and the value of the targeting attribute are **strings**. Please reach out to the Nimbus SDK team for any targeting attributes that require integer comparison, or any other richer `JEXL` expressions that cannot be done with strings.
 :::
 
 
-### How to add a new attribute
+### How to Add a New Attribute
 In [NimbusSetup.kt](https://github.com/mozilla-mobile/fenix/blob/main/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt#L61) `NimbusAppInfo` now optionally takes in a map `customTargetingAttributes` that will be used to add custom targeting. Simply add a new key-value pair to the map and it will be available for targeting. For example:
 ```kotlin
 val appInfo = NimbusAppInfo(
@@ -33,7 +33,7 @@ val appInfo = NimbusAppInfo(
 
 Note that since we need to add the targeting attributes on the client code, the attribute changes will have to ride the trains before they are available for targeting.
 
-## Adding the attribute on experimenter
+## Adding the Attribute on Experimenter
 After the targeting attribute is ready on the app, you will need to modify experimenter to allow creating experiments that target the attribute you created. Follow the instructions on [the custom audiences page](/advanced/custom-audiences#how-to-add-a-new-custom-audience) to add the new targeting on experimenter.
 :::warning
 The targeting `JEXL` expression on experimenter **must** use the same name as the key given to the SDK. For example, if the app defines a key-value pair, with key `isFirstRun`. experimenter expression must use the same name (i.e `isFirstRun`).

--- a/docs/platform-guides/android/integration.md
+++ b/docs/platform-guides/android/integration.md
@@ -1,10 +1,12 @@
 ---
 id: getting-started-for-android-engineers
-title: Getting Started
+title: Integration
 slug: /platform-guides/android/integration
 ---
 
-# Introduction
+How to set up the Nimbus SDK with a new Android app.
+
+## Introduction
 
 Nimbus is an experimentation platform from Mozilla.
 
@@ -12,7 +14,7 @@ This document shows you how to set up the Nimbus SDK with a new Android app. It 
 
 [nimbus-cli]: https://github.com/mozilla/application-services/tree/main/components/support/nimbus-cli
 
-# Building with Nimbus
+## Building with Nimbus
 
 Nimbus is distributed through bundled Rust code as part of Mozilla's Application Services ["Megazord"](https://github.com/mozilla/application-services/blob/main/docs/design/megazords.md).
 
@@ -80,7 +82,7 @@ nimbus {
 
 In this case, it should generate a file named in the `nimbus.fml.yaml` file. In the case of Fenix, this is called `FxNimbus`.
 
-# The start-up sequence
+## The Start-Up Sequence
 
 Before using Nimbus in your Android app, you need to start it.
 
@@ -180,7 +182,7 @@ To connect it to the Nimbus object, we need to tell the `NimbusBuilder`. In this
     }.build(appInfo)
 ```
 
-### Handling First Run experiments
+### Handling First Run Experiments
 
 Since `fetchExperiments` from the remote settings URL is slow, and we wish to be able have access to the Nimbus experimental configuration as early in start up as possible, Nimbus downloads and caches the experiment recipes on the `n`th run of the app and only applies them and makes them available to the app at the beginning of the _next_ i.e. the `(n + 1)`th run of the app.
 
@@ -198,7 +200,7 @@ Astute readers will notice that when `n = 0`, i.e. the very first time the app i
 
 The `initial_experiments.json` file can be downloaded, either as part of the build, or in an automated/timed job. e.g. this is the [Github Action workflow used by Fenix](https://github.com/mozilla-mobile/fenix/blob/main/.github/workflows/fenix-update-nimbus-experiments.yml).
 
-#### To check if the firstrun experiment merged into beta to catch the next release
+#### To Check If the Firstrun Experiment Merged into Beta to Catch the Next Release
 First run experiments need to be in the beta build 8-11 days before release, so that they are in the release candidate.  Final build happens 8 days before release on Monday - so best to get in and uplift approved by Friday at the latest.  On Android the Release Candidate goes out to 5% of users a week before general release.
 
 After the change is made in Nimbus/Experimenter to launch, enrollment end, or end the experiment - a github action kicks off the PR automatically to update 'initial_experiments.json'.  Then a mobile engineer needs to r+ that PR and request uplift to Beta.  If you replace 'version number' in the following file name, you can check this file to see if the experiment config is in the right state before release candidate build https://raw.githubusercontent.com/mozilla-mobile/firefox-android/releases_v'version number'/fenix/app/src/main/res/raw/initial_experiments.json.

--- a/docs/platform-guides/android/microsurveys.md
+++ b/docs/platform-guides/android/microsurveys.md
@@ -8,7 +8,7 @@ The microsurvey feature is an extension of the [messaging framework](/messaging/
 
 It’s composed the of two main user interfaces:
 
-## The prompt
+## The Prompt
 It is the first UI widget which users see, the prompt is an invitation to start the survey, it’s shown when all the triggers indicated are met, until the user decides to start the survey, choose to cancel or the maximum number of shows is met.
 
 <img src="/img/mobile/microsurveys/prompt.png" alt="Prompt view" className="img-sm-center"/>
@@ -18,7 +18,7 @@ It is the first UI widget which users see, the prompt is an invitation to start 
 2. The button starts the survey and shows the survey sheet.
 3. The cancel button, dismiss the survey, and it won't be shown anymore to users.
 
-## The sheet
+## The Sheet
 The survey sheet is shown after the user clicks “Continue” in the prompt, here the user will be able to fill the survey. It will be shown until the user clicks the “X” button (1) or drag down the sheet, which will make the prompt visible again.
 
 <img src="/img/mobile/microsurveys/sheet.png" alt="Sheet view" className="img-sm-center"/>
@@ -28,10 +28,10 @@ The survey sheet is shown after the user clicks “Continue” in the prompt, he
 2. The submit button which will send the survey result if at least one field is selected.
 3. The question and options both can be customized.
 
-## Survey JSON recipe
+## Survey JSON Recipe
 Microsurveys are built on top of the already existing [messaging framework](/messaging/desktop/mobile-messaging), with an extra field called `microsurvey-config`  to control the survey, if you are not familiar please take a look at it first.
 
-## Customize the prompt
+## Customize the Prompt
 On the prompt, you can customize the title by using the same `title` field as normal message, for example:
 
 ```json
@@ -47,7 +47,7 @@ On the prompt, you can customize the title by using the same `title` field as no
 
 You can either provide a `string` containing the text that you would like to show or reference a string bundled with the app. The latter is the preferred method so the survey can support multiple languages.
 
-## Customize the sheet
+## Customize the Sheet
 In the sheet we can control the question, answers and UTM parameters for the privacy policy link.
 
 For the question, just use the `text` field at the same level as the `title` one, similar to the latter where you can provide either a string or a bundled string id.

--- a/docs/platform-guides/android/mobile-ui.md
+++ b/docs/platform-guides/android/mobile-ui.md
@@ -4,11 +4,13 @@ title: Required UI
 slug: /platform-guides/android/mobile-ui
 ---
 
-# User Interface requirements
+Required user interface components for apps integrating with the Nimbus SDK.
+
+## User Interface Requirements
 
 Currently Nimbus provides no user-interface components of its own, though provides API to connect to existing settings screens.
 
-## Global opt-out/opt-in for experiments
+## Global Opt-Out/Opt-In for Experiments
 
 The settings page should include a `Studies` toggle, which allows users to opt-in or opt-out of experiments. The example from Firefox for iOS is shown:
 
@@ -20,7 +22,7 @@ Toggling the `Studies` flag should set the `Nimbus` value for `globalUserPartici
 nimbus.globalUserParticipation = flag
 ```
 
-## Resetting telemetry identifiers
+## Resetting Telemetry Identifiers
 
 During experiment enrollment, telemetry is generated which can connect the user to the experiment enrollment.
 
@@ -32,7 +34,7 @@ nimbus.resetTelemetryIdentifiers()
 
 This disqualifies existing enrollments. and breaks any connection with experiment enrollment and the enrollment telemetry.
 
-## QA tooling
+## QA Tooling
 
 > The following are nice-to-haves, obviated by the use of the [`nimbus-cli`][nimbus-cli].
 
@@ -48,7 +50,7 @@ The above shows a non-user visible settings screen in Fenix. The toggle sets a `
 
 The preview collection is loaded on the next restart, and available to the app on the restart after that.
 
-### Manual opt-in of experiments
+### Manual Opt-In of Experiments
 
 To allow the manual opt-in of a particular branch, the app must provide a screen to list all available experiments:
 

--- a/docs/platform-guides/android/onboarding.md
+++ b/docs/platform-guides/android/onboarding.md
@@ -4,7 +4,7 @@ title: Onboarding
 slug: /platform-guides/android/onboarding
 ---
 
-# Introduction
+## Introduction
 The onboarding feature enables experimentation with the 'new user onboarding flow'. The onboarding flow is presented to the user on each new install and is made up of a series of full screen 'views', referred to as '**cards**'. The purpose of the onboarding flow is to enable the user to configure a small number of app enhancing settings. Each card provides context for each setting and the ability to enable/skip.
 
 The onboarding feature enables staff — most likely experiment owners, product owners, user research and marketing teams to customize each card's:
@@ -15,7 +15,7 @@ The onboarding feature enables staff — most likely experiment owners, product 
 - button copy
 - sequencing
 
-# About this document
+## About This Document
 This document is a guide for staff who wish to configure the new user onboarding flow through the experimenter interface.
 
 It is also a living document:
@@ -24,13 +24,13 @@ It is also a living document:
 - card types may be added
 - card attributes may be added 
 
-# Scene setting
+## Scene Setting
 
 The onboarding feature is built on top of Nimbus, Mozilla's experimentation platform. Nimbus allows you to send bits of configuration to application features from Experimenter, the web-application staff use to launch and manage experiments and rollouts.
 
 Using Experimenter in the general case is documented elsewhere, so this document is specifically concerned with configuring the onboarding feature.
 
-# References
+## References
 For the most up-to-date configurations, the main code base will always be the best place to check.
 - [Nimbus manifest](https://github.com/mozilla-mobile/firefox-android/blob/main/fenix/app/nimbus.fml.yaml)
 - [onboarding feature manifest](https://github.com/mozilla-mobile/firefox-android/blob/main/fenix/app/onboarding.fml.yaml)
@@ -39,7 +39,7 @@ For the most up-to-date configurations, the main code base will always be the be
 The onboarding feature is a [first run experiment](/advanced/first-run-experiments)
 :::
 
-# Creating an experiment
+## Creating an Experiment
 Only **values that differ** from the default card(s) needs providing by the Experimenter. E.g:
 
 #### Existing default card
@@ -90,7 +90,7 @@ Only **values that differ** from the default card(s) needs providing by the Expe
    }
 ```
 
-# Card definition
+## Card Definition
 | Attribute              | Type                        | Description                                  | Notes                                                                                                         |       
 |------------------------|-----------------------------|----------------------------------------------|---------------------------------------------------------------------------------------------------------------|
 | card-type              | Card Type                   | The type of the card                         | [See defined cards types](#card-types)                                                                        |
@@ -103,24 +103,24 @@ Only **values that differ** from the default card(s) needs providing by the Expe
 | primary-button-label   | Free text  or  Resource ID  | The text to display on the primary button    |                                                                                                               | 
 | secondary-button-label | Free text or  Resource ID   | The text to display on the secondary button  |                                                                                                               | 
 
-## Card types
+## Card Types
 - default-browser
 - add-search-widget
 - sync-sign-in
 - notification-permission
 
-# Default cards
+## Default Cards
 By default, the app is bundled with a collection of pre-defined cards which will be used if no other configuration is provided for the cards. See the [appendix](#default-cards-overview) for an overview of the default cards or the [code](https://github.com/mozilla-mobile/firefox-android/blob/bfb1acebe37ea6fcff80d12f4084a54bb8a6cd1a/fenix/app/onboarding.fml.yaml#L4) the most up-to-date configuration. 
 
-# Available resources
+## Available Resources
 
-## String resources
+## String Resources
 All existing app strings are available to Experimenter. [See the full list here](https://github.com/mozilla-mobile/firefox-android/blob/main/fenix/app/src/main/res/values/strings.xml).
 Free text may also be used instead of a string resource.
 
 ⚠️ Localization of **Free Text** is not currently supported.
 
-## Image resources
+## Image Resources
 
 ### Default
 | Card type               | Resource ID                |
@@ -135,13 +135,13 @@ Free text may also be used instead of a string resource.
 |-------------------------|-------------------------------------------------------------------|
 | default-browser         | ic_onboarding_key_features, ic_onboarding_key_features_icons_only |
 
-# Appendix
+## Appendix
 
 The add search widget is part of an ongoing experiment found here: [Android Onboarding - search widget](https://experimenter.services.mozilla.com/nimbus/android-onboarding-search-widget/summary)
 
-## Default cards overview
+## Default Cards Overview
 
-### Default browser card
+### Default Browser Card
 | Attribute              | Value                                                 |
 |------------------------|-------------------------------------------------------|
 | card-type              | default-browser                                       |
@@ -154,7 +154,7 @@ The add search widget is part of an ongoing experiment found here: [Android Onbo
 | primary-button-label   | juno_onboarding_default_browser_positive_button       |
 | secondary-button-label | juno_onboarding_default_browser_negative_button       |
 
-### Add search widget
+### Add Search Widget
 | Attribute              | Value                                             |
 |------------------------|---------------------------------------------------|
 | card-type              | add-search-widget                                 |
@@ -167,7 +167,7 @@ The add search widget is part of an ongoing experiment found here: [Android Onbo
 | primary-button-label   | juno_onboarding_add_search_widget_positive_button |
 | secondary-button-label | juno_onboarding_add_search_widget_negative_button |
 
-### Sync card
+### Sync Card
 | Attribute              | Value                                   |
 |------------------------|-----------------------------------------|
 | card-type              | sync-sign-in                            |
@@ -180,7 +180,7 @@ The add search widget is part of an ongoing experiment found here: [Android Onbo
 | primary-button-label   | juno_onboarding_sign_in_positive_button |
 | secondary-button-label | juno_onboarding_sign_in_negative_button |
 
-### Notification card
+### Notification Card
 | Attribute              | Value                                                   |
 |------------------------|---------------------------------------------------------|
 | card-type              | notification-permission                                 |

--- a/docs/platform-guides/android/preview-testing.md
+++ b/docs/platform-guides/android/preview-testing.md
@@ -4,9 +4,11 @@ title: Android Testing
 slug: /platform-guides/android/preview-testing
 ---
 
-# Android Testing
+How to test experiment preview on Android using the staging server.
 
-## Launching an experiment to Preview the stage server
+## Android Testing
+
+## Launching an Experiment to Preview the Stage Server
 
 The first step to testing the preview flow is to launch an experiment. Go to [experimenter](https://experimenter.services.mozilla.com/) and create your experiment.
 
@@ -14,7 +16,7 @@ For experiments that are already live, go to the summary page. For experiments t
 
 ![Launch to Preview Button](/img/preview/preview-button.png)
 
-## How to test
+## How to Test
 
    Here is a [quick overview video overview of testing on Android](https://drive.google.com/file/d/1SkcWOEsMUjhpwScfE1Hbss53XAII4IkJ/view).  That is the best place to start to understand the QA landscape.  
 

--- a/docs/platform-guides/desktop/enroll-locally.md
+++ b/docs/platform-guides/desktop/enroll-locally.md
@@ -4,7 +4,9 @@ title: Local Enrollment
 slug: /platform-guides/desktop/enroll-locally
 ---
 
-# Debugging an experiment from experimenter locally
+How to enroll in an experiment locally for debugging, using either Nimbus Developer Tools or the Browser Console.
+
+## Debugging an Experiment from Experimenter Locally
 
 Trying to iterate on an experiment in Preview on experimenter.services.mozilla.com can be painful, because even after you change something and post to preview, you have a wait a while for the updated recipe to be propagated to the CDN.
 
@@ -33,7 +35,7 @@ For a more comprehensive overview of the Nimbus Developer Tools, including addit
 
 ## Option B: Manual Enrollment via Browser Console
 
-### Enable Nimbus debugging
+### Enable Nimbus Debugging
 
 * In `about:config`, set:
   * `nimbus.debug` to `true`
@@ -44,7 +46,7 @@ For a more comprehensive overview of the Nimbus Developer Tools, including addit
   * `devtools.chrome.enabled` to `true`
   * `devtools.debugger.remote-enabled` to `true`
 
-### Prepare a few things:
+### Prepare a Few Things
 * Load `about:studies` and unenroll this profile from anything that might interfere
 * On the Experimenter page for your experiment, select the contents of the `Recipe JSON` field from the `Details` tab, and copy it into your Copy/Paste buffer
 

--- a/docs/platform-guides/desktop/feature-api.mdx
+++ b/docs/platform-guides/desktop/feature-api.mdx
@@ -13,7 +13,7 @@ If you are familiar with Normandy and are trying to migrate a feature, you may w
 
 ## About the Feature API
 
-### Can I use this?
+### Can I Use This?
 
 For the JS implementation you can import `ExperimentAPI.sys.mjs` in the parent process or a privileged child process. We _do_ support First run experiments on Windows, holdbacks, and rollouts.
 

--- a/docs/platform-guides/desktop/incident-response.md
+++ b/docs/platform-guides/desktop/incident-response.md
@@ -4,11 +4,13 @@ title: Incident Response
 slug: /platform-guides/desktop/incident-response
 ---
 
+How to use the prefFlips feature for incident response pref flips on Desktop Firefox 129+.
+
 As of Firefox 129 (and 128.2 ESR), Firefox supports flipping any pref via
 Nimbus. This is done with the `prefFlips` feature. The JSON Schema definition
 for the feature value can be found [here][jsonschema].
 
-# Warning
+## Warning
 
 This feature is *not intended for use in experimentation*. If you want to do an
 experiment on some number of prefs in Firefox, you **must** register these prefs
@@ -21,7 +23,7 @@ with caution. Remember: with great power comes great responsibility.
 
 Only the release management team can approve incident reponse pref flips.
 
-# Behaviour
+## Behaviour
 
 When a client enrolls into a rollout using this feature, Nimbus will set (or
 unset) all the prefs to the values specified. Prefs on the `user` branch will
@@ -47,7 +49,7 @@ will be unenrolled.
 The incident response feature *cannot* be used with other features.
 
 
-# Launching a Pref Flip
+## Launching a Pref Flip
 
 1. Create a new experiment in
 [Experimenter](https://experimenter.services.mozilla.com/) with an
@@ -136,7 +138,7 @@ Desktop.
 
 <a id="example-configuration"></a>
 
-# Example Configuration
+## Example Configuration
 
 ```json
 {
@@ -157,7 +159,7 @@ Desktop.
 }
 ```
 
-# Causes of Unenrollment
+## Causes of Unenrollment
 
 ## Mismatched Types
 

--- a/docs/platform-guides/desktop/migration-guide.md
+++ b/docs/platform-guides/desktop/migration-guide.md
@@ -4,6 +4,8 @@ title: Migration Guide
 slug: /platform-guides/desktop/migration-guide
 ---
 
+How to migrate Desktop front-end Normandy pref experiments to Nimbus-controlled experiments or rollouts.
+
 ## To migrate front-end normandy prefs to Nimbus controlled experiments or rollouts
 This guide will help you migrate your Desktop front-end code to run experiments with Nimbus, while still being able to use preferences for default and user-override values
 
@@ -12,7 +14,7 @@ Prerequisites:
 * You don't use the `user branch` of each pref for anything other than actual user-defined values or testing (see docs on [order of precedence](/platform-guides/desktop/feature-api#configuration-sources))
 * Your code can import a ESM
 
-### An illustrative example (about:myself)
+### An Illustrative Example (about:myself)
 
 For the purposes of this guide, we will be migrating an imaginary about page (`about:myself`), which uses the following preferences defined in `firefox.js`:
 

--- a/docs/platform-guides/desktop/pref-experiments.md
+++ b/docs/platform-guides/desktop/pref-experiments.md
@@ -4,6 +4,8 @@ title: Pref Experiments
 slug: /platform-guides/desktop/pref-experiments
 ---
 
+How Nimbus supports preference-setting experiments on Desktop Firefox 107+.
+
 As of Firefox 107, Nimbus supports experiments that set preferences on Desktop.
 Unlike Normandy, Nimbus cannot set arbitrary preferences; instead, the
 preferences that may be set are determined by the feature manifest.
@@ -40,7 +42,7 @@ If you've read to the end of this and aren't scared off, please read [this
 section](#pref-branches) on which branch your feature should write to.
 ::::
 
-## Pref branches
+## Pref Branches
 
 Each variable using `setPref` must specify which branch will be written to. There are two branches,
 each with its trade-offs:

--- a/docs/platform-guides/desktop/preview.md
+++ b/docs/platform-guides/desktop/preview.md
@@ -16,7 +16,7 @@ These steps only apply to Firefox Desktop Version 90+. You can find [instruction
 
 ![Launch to Preview Button](/img/preview/preview-button.png)
 
-### Self-Testing with Nimbus Dev Tools Add-on
+## Self-Testing with Nimbus Dev Tools Add-on
 If you aren't a developer, don't let the "Dev Tools" or add-on scare you away.  This is the easier path!  
 
 Here is a 65 second video on [how to install Nimbus dev tools](https://mozilla.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=b7b2d02b-79ba-43a0-a708-b2a60107f0bf).  Watching the video takes half the time to getting Nimbus Dev Tools installed.  Here is the [link to docs on how to use Nimbus Dev Tools](https://experimenter.info/nimbus-devtools-guide#installation).  The very first link on that page is to the [Nimbus DevTools GitHub repository](https://github.com/mozilla-extensions/nimbus-devtools/releases), where you can find the one click XPI file install.
@@ -25,10 +25,10 @@ Here is a 5 minute video on [using Nimbus Dev Tools to test a simple experiment]
 
 Here is the link to the [DevTool user guide](https://experimenter.info/nimbus-devtools-guide/) 
 
-### How do I know if I have a simple experiment
+## How Do I Know If I Have a Simple Experiment
 There is a Miro flow that can [help determine if you have a good test case here](https://miro.com/app/board/uXjVK_27t2o=/?share_link_id=702720260336).  If it asks for a password - "patterns".  Reach out in #ask-experimenter if you are unsure and someone can help you determine the complexity. 
 
-### Self-Testing without Nimbus Dev Tools
+## Self-Testing Without Nimbus Dev Tools
 
 2. Scroll down to the **Preview Url** section of the page. Select the branch you want and copy the `about:studies` URL.
 
@@ -36,6 +36,6 @@ There is a Miro flow that can [help determine if you have a good test case here]
 
 4. You should be enrolled! To exit the experiment, go to `about:studies` and click "Remove"
 
-#### Earlier Desktop Firefox versions (<90)
+### Earlier Desktop Firefox Versions (<90)
 
 To use preview with earlier versions of Firefox, you can use your Browser Toolbox devtools to run [this code snippet](https://gist.github.com/piatra/fb3876257f876386da104df593000ce9).

--- a/docs/platform-guides/desktop/targeting-debug.md
+++ b/docs/platform-guides/desktop/targeting-debug.md
@@ -1,17 +1,19 @@
 ---
 id: desktop-targeting-debug
-title: Desktop
+title: Targeting Debug
 slug: /platform-guides/desktop/targeting-debug
 ---
 
-# Debugging Targeting expressions
+How to debug targeting expressions using ASRouter devtools on Desktop.
 
-## How to enable ASRouter devtools
+## Debugging Targeting Expressions
+
+## How to Enable ASRouter Devtools
 
 - In `about:config`, set `browser.newtabpage.activity-stream.asrouter.devtoolsEnabled` to `true`
 - Visit `about:newtab#devtools-targeting` to see the devtools (you need to copy-paste this manually to navigate).
 
-## Overview of ASRouter devtools
+## Overview of ASRouter Devtools
 
 ![Devtools image](/img/desktop/desktop-devtools.png)
 
@@ -27,7 +29,7 @@ Inside the textarea targeting expressions can be written and evaluated using the
 | Correctly formatted JEXL expression<br/> referencing unknown variables | ❌        | Empty result    | Using unknown variables is an error, result is neither true nor false |
 | JEXL expression with syntax error                                      | ❌        | <ERR_MSG>       | Full error message is shown                                           |
 
-## Builtin functions and examples
+## Builtin Functions and Examples
 
 The full list of available functions can be seen in [FilterExpressions.sys.mjs](https://searchfox.org/mozilla-central/source/toolkit/components/utils/FilterExpressions.sys.mjs).
 

--- a/docs/platform-guides/desktop/testing.mdx
+++ b/docs/platform-guides/desktop/testing.mdx
@@ -7,6 +7,8 @@ slug: /platform-guides/desktop/testing
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
+Test helpers for writing automated tests for Nimbus feature integrations on Desktop.
+
 In order to make testing easier we created some helpers that can be accessed by including
 
 ```js
@@ -15,7 +17,7 @@ const { ExperimentFakes } = ChromeUtils.importESModule(
 );
 ```
 
-## Testing your feature integrating with Nimbus
+## Testing Your Feature Integrating with Nimbus
 
 You need to provide a feature configuration and await enrollment
 

--- a/docs/platform-guides/ios/custom-targeting.md
+++ b/docs/platform-guides/ios/custom-targeting.md
@@ -1,9 +1,9 @@
 ---
 id: ios-custom-targeting
-title: iOS
+title: Custom Targeting
 slug: /platform-guides/ios/custom-targeting
 ---
-# Adding new targeting attributes to iOS
+## Adding New Targeting Attributes to iOS
 
 :::warning DEPRECATED
 **This method of adding new targeting attributes is deprecated. Please use the method described in the [Recorded Targeting Context doc](/advanced/recording-targeting-context#adding-new-fields).**
@@ -12,7 +12,7 @@ slug: /platform-guides/ios/custom-targeting
 This page demonstrates how to add new targeting attributes to iOS, enabling experiment creators more specific targeting.
 For more general documentation on targeting custom audiences, check out [the custom audiences docs](/advanced/custom-audiences)
 
-## Adding the attribute to the application
+## Adding the Attribute to the Application
 The Nimbus SDK exposes a new `customTargetingAttributes` parameter in its initializer that is a `[String:String]` map. We can take advantage of this parameter to pass in new targeting attributes without modifying the Nimbus SDK at all.
 :::warning
 A current limitation is that both the key and the value of the targeting attribute are **strings**. Please reach out to the Nimbus SDK team for any targeting attributes that require integer comparison, or any other richer `JEXL` expressions that cannot be done with strings.
@@ -21,13 +21,13 @@ A current limitation is that both the key and the value of the targeting attribu
 Note that since we need to add the targeting attribute on the client code, the attribute changes will have to ride the trains before they are available for targeting.
 
 
-### How to add a new attribute
+### How to Add a New Attribute
 In [AppDelegate+Experiments.swift](https://github.com/tarikeshaq/firefox-ios/blob/add-first-run-targeting/Client/Application/AppDelegate%2BExperiments.swift#L17) the map `customTargetingAttributes` will be used to add custom targeting. Simply add a new key-value pair to the map and it will be available for targeting. For example:
 ```swift
 Experiments.customTargetingAttributes =  ["isFirstRun": "\(isFirstRun)", "newTargetingAttributeName": "targetingAttributeValue"]
 ```
 
-## Adding the attribute on experimenter
+## Adding the Attribute on Experimenter
 After the targeting attribute is ready on the app, you will need to modify experimenter to allow creating experiments that target the attribute you created. Follow the instructions on [the custom audiences page](/advanced/custom-audiences#how-to-add-a-new-custom-audience) to add the new targeting on experimenter.
 :::warning
 The targeting `JEXL` expression on experimenter **must** use the same name as the key given to the SDK. For example, for targeting users on their first run, the app defines a key-value pair, with key `isFirstRun`. The experimenter expression must use the same name (i.e `isFirstRun`)

--- a/docs/platform-guides/ios/integration.md
+++ b/docs/platform-guides/ios/integration.md
@@ -1,8 +1,10 @@
 ---
 id: getting-started-for-ios-engineers
-title: Getting Started
+title: Integration
 slug: /platform-guides/ios/integration
 ---
+
+How to set up the Nimbus SDK with a new iOS app.
 
 ## Introduction
 
@@ -130,7 +132,7 @@ To connect it to the Nimbus object, we need to tell the `NimbusBuilder`. In this
         .build(appInfo: appInfo)
 ```
 
-### Handling First Run experiments
+### Handling First Run Experiments
 
 Since `fetchExperiments` from the remote settings URL is slow, and we wish to be able have access to the Nimbus experimental configuration as early in start up as possible, Nimbus downloads and caches the experiment recipes on the `n`th run of the app and only applies them and makes them available to the app at the beginning of the _next_ i.e. the `(n + 1)`th run of the app.
 
@@ -148,7 +150,7 @@ Astute readers will notice that when `n = 0`, i.e. the very first time the app i
 
 The `initial_experiments.json` file can be downloaded, either as part of the build, or in an automated/timed job. e.g. this is the [Github Action workflow used by Firefox for iOS](https://github.com/mozilla-mobile/firefox-ios/blob/main/.github/workflows/update-nimbus-experiments.yml).
 
-#### To check if the firstrun experiment merged into beta to catch the next release
+#### To Check If the Firstrun Experiment Merged into Beta to Catch the Next Release
 First run experiments need to be in the beta build 8-11 days before release, so that they are in the release candidate.  Final build happens 8 days before release on Monday - so best to get in and uplift approved by Friday at the latest.  
 
 After the change is made in Nimbus/Experimenter to launch, enrollment end, or end the experiment - a github action kicks off the PR automatically to update 'initial_experiments.json'.  Then a mobile engineer needs to r+ that PR and request uplift to Beta.  If you replace 'version number' in the following file name, you can check this file to see if the experiment config is in the right state before release candidate build https://raw.githubusercontent.com/mozilla-mobile/firefox-ios/release/v'version number'/Client/Experiments/initial_experiments.json.

--- a/docs/platform-guides/ios/onboarding.md
+++ b/docs/platform-guides/ios/onboarding.md
@@ -4,7 +4,7 @@ title: Onboarding
 slug: /platform-guides/ios/onboarding
 ---
 
-# Introduction
+## Introduction
 The onboarding feature enables experimentating with the 'new user onboarding flow'. The onboarding flow is presented to the user on each new install, and is made up of a series of full screen 'views', referred to as '**cards**'. The purpose of the onboarding flow is to enable the user to configure a small number of app enhancing settings. Each card provides context for each setting and the ability to take an appropratie action, or skip to the next card.
 
 The onboarding feature enables customize each card's:
@@ -17,7 +17,7 @@ The onboarding feature enables customize each card's:
 - number of buttons (one or two)
 - sequencing
 
-# About this document
+## About This Document
 This document is a guide for staff who wish to configure the new user onboarding flow through the experimenter interface.
 
 It is also a living document:
@@ -26,13 +26,13 @@ It is also a living document:
 - card types may be added
 - card attributes may be added
 
-# Scene setting
+## Scene Setting
 
 The onboarding feature is built on top of Nimbus, Mozilla's experimentation platform. Nimbus allows you to send bits of configuration to application features from Experimenter, the web-application staff use to launch and manage experiments and rollouts.
 
 Using Experimenter in the general case is documented elsewhere, so this document is specifically concerned with configuring the onboarding feature.
 
-# References
+## References
 For the most up-to-date configurations, the main code base will always be the best place to check.
 - [Nimbus manifest](https://github.com/mozilla-mobile/firefox-ios/blob/main/nimbus.fml.yaml)
 - [Onboarding feature manifest](https://github.com/mozilla-mobile/firefox-ios/blob/main/nimbus-features/onboardingFrameworkFeature.yaml)
@@ -41,7 +41,7 @@ For the most up-to-date configurations, the main code base will always be the be
 The onboarding feature is a [first run experiment](/advanced/first-run-experiments)
 :::
 
-# Creating an experiment
+## Creating an Experiment
 Only **values that differ** from the card's default values need to be provided to Experimenter. E.g:
 
 #### Existing default card
@@ -105,7 +105,7 @@ Only **values that differ** from the card's default values need to be provided t
    }
 ```
 
-# Feature Definition
+## Feature Definition
 The onboarding feature is split into several values:
 - conditions
 - cards
@@ -175,7 +175,7 @@ This is a property for the whole onboarding, and controls whether there is an `x
 }
 ```
 
-# Available resources
+## Available Resources
 
 ## TextID
 All existing app strings are available to Experimenter. [See the full list here](https://github.com/mozilla-mobile/firefox-ios/blob/main/Client/Frontend/Strings.swift). Note, that only strings with a `tableName` and a `key` can be used.
@@ -200,9 +200,9 @@ Free text may also be used instead of a string resource.
 | sync-devices-ctd | The sync image for CTD campaign. |
 | notification-ctd | The notifications image for CTD campaign. |
 
-# Appendix
+## Appendix
 
-## Default cards overview
+## Default Cards Overview
 
 ### Default Welcome Card
 | Attribute     | Value                                          |

--- a/docs/platform-guides/ios/preview-testing.md
+++ b/docs/platform-guides/ios/preview-testing.md
@@ -4,9 +4,11 @@ title: iOS Testing
 slug: /platform-guides/ios/preview-testing
 ---
 
-# iOS Testing
+How to test experiment preview on iOS using the staging server.
 
-## Launching an experiment to Preview the stage server
+## iOS Testing
+
+## Launching an Experiment to Preview the Stage Server
 
 The first step to testing the preview flow is to launch an experiment. Go to [experimenter](https://experimenter.services.mozilla.com/) and create your experiment.
 
@@ -14,7 +16,7 @@ For experiments that are already live, go to the summary page. For experiments t
 
 ![Launch to Preview Button](/img/preview/preview-button.png)
 
-## How to test
+## How to Test
 
    Here is a [7 minute video overview of testing on iOS](https://drive.google.com/file/d/1SkcWOEsMUjhpwScfE1Hbss53XAII4IkJ/view).  That is the best place to start to understand the landscape.  Testing is possible by anyone (technical or not) with relative ease.
 

--- a/docs/platform-guides/web/integration.md
+++ b/docs/platform-guides/web/integration.md
@@ -1,8 +1,10 @@
 ---
-id: getting-started-for-nimbus-web-integration
-title: Getting Started
+id: web-integration
+title: Integration
 slug: /platform-guides/web/integration
 ---
+
+How to integrate Nimbus (Cirrus) into your web application.
 
 ## Introduction
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -99,7 +99,7 @@ module.exports = {
           type: "category",
           label: "Web (Cirrus)",
           items: [
-            "platform-guides/web/getting-started-for-nimbus-web-integration"
+            "platform-guides/web/web-integration"
           ]
         },
         {


### PR DESCRIPTION
Because

* Headings were inconsistent across platform guide articles
* Several articles had generic titles like "Desktop", "Android", "iOS"
* Summary paragraphs were missing from many articles
* H1 headings were used inside articles instead of H2

This commit

* Fixes heading nesting (`##` as top-level) across all 18 platform guide articles
* Title-cases all headings
* Adds summary paragraphs to articles missing them
* Renames generic titles to be descriptive of article content
* Updates `sidebars.js` for renamed web integration doc ID

fixes #746