### PR TITLE
chore: consistent formatting for messaging system

### DIFF
--- a/docs/messaging/desktop/_category_.yml
+++ b/docs/messaging/desktop/_category_.yml
@@ -1,3 +1,0 @@
-label: "Messaging"
-collapsible: true
-collapsed: true

--- a/docs/messaging/desktop/mobile-messaging.mdx
+++ b/docs/messaging/desktop/mobile-messaging.mdx
@@ -5,7 +5,7 @@ slug: /messaging/desktop/mobile-messaging
 sidebar_position: 7
 ---
 
-# Introduction
+## Introduction
 The mobile messaging system is a feature of Firefox on iOS and Android, designed to send in-app messages directly to users without going through a release cycle.
 
 It allows staff— most likely experiment owners, product owners, user research and marketing teams—
@@ -23,7 +23,7 @@ It allows staff— most likely experiment owners, product owners, user research
 [fenix-attributes-eng]:          https://github.com/mozilla-mobile/firefox-android/blob/main/fenix/app/src/main/java/org/mozilla/fenix/messaging/CustomAttributeProvider.kt
 [fenix-trigger-expressions-fml]: https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/components/service/nimbus/messaging.fml.yaml
 
-# About this document
+## About This Document
 
 This document is a guide for staff who wish to send message users through the experimenter interface.
 
@@ -46,7 +46,7 @@ import TabItem from "@theme/TabItem";
 - Added notification surface and associated trigger expressions.
 - v117 - added `experiment` property to message, removed `message-under-experiment`.
 
-## Scene setting
+## Scene Setting
 
 Nimbus Mobile Messaging is built on top of Nimbus, Mozilla's experimentation platform. Nimbus allows you to send bits of configuration to application features from Experimenter, the web-application staff use to launch and manage experiments and rollouts.
 
@@ -78,7 +78,7 @@ The messages that are sent are specified as JSON in the "Value" text area on thi
 
 We will start with this simple example to introduce the concepts, then add more as we go.
 
-## Anatomy of a message
+## Anatomy of a Message
 
 Messages have a number of components:
 
@@ -200,7 +200,7 @@ To reduce errors and to allow re-use, action URLs can be named. By convention, t
 
 If the specified `action` property contains a `://` it is treated as a bare URL, so one-off URLs may be specified.
 
-#### String substiutions
+#### String Substitutions
 
 Before the final URL is opened, a variable subsitution is made, so identifiers within a pair of braces may be made part of the URL.
 
@@ -245,7 +245,7 @@ This currently code for:
  - the message `priority`. Messages will be shown in descending order of priority.
  - the `max-display-count`. Messages will be shown to the user for this number of sessions before the message expires.
 
-## Localization of messages
+## Localization of Messages
 
 Localization of strings and messages is not fully developed in Nimbus: the intention is to integrate with the existing tooling for localizing strings.
 
@@ -306,7 +306,7 @@ For each of the messages,
 
 In this manner the locale can be only one value at a time, and only one version of the message is eligible for display at any one time.
 
-## Experimenting with messages
+## Experimenting with Messages
 
 So far, we have talked about using Experimenter to push out messages as single branch experiments.
 
@@ -325,7 +325,7 @@ We should also tell the system that the message is under experiment. This is don
 }
 ```
 
-### Experimenting with localized messages
+### Experimenting with Localized Messages
 
 We saw when [localizing messages](#localization-of-messages) that the branch provided different messages based on adding additional trigger expressions.
 
@@ -383,7 +383,7 @@ It is important that:
 
 Since these triggers are mutually exclusive, the user will only ever be exposed to one message under experiment.
 
-### Control messages
+### Control Messages
 
 For most messages in experiments, we'll need to specify a control message.
 
@@ -451,7 +451,7 @@ For localized messages, we will need to provide a set of contol messages that ma
 
 Control messages (i.e. messages with `is-control` set to `true`) that do not have an `experiment` set to `{experiment}` will be reported by the client as malformed, since we can't ascertain which experiment they came from.
 
-### Displaying the control message
+### Displaying the Control Message
 
 The control message is the placebo, so doesn't make any sense to display to the user, so when a control message is selected for display, what should a message surface actually display?
 
@@ -476,7 +476,7 @@ The `on-control` property controls what happens in this case:
 
 By default, `on-control` is set to `show-next-message`.
 
-### Advanced uses of the `{experiment}` subsitution
+### Advanced Uses of the {experiment} Substitution
 
 The literal string `{experiment}` can appear anywhere in the feature configuration, including the message key allows for some deduplication. For example, a regularly repeating message could be set up with message keys derived from the experiment slug.
 
@@ -511,7 +511,7 @@ The literal string `{experiment}` can appear anywhere in the feature configurati
 }
 ```
 
-## Events emitted
+## Events Emitted
 
 ### Nimbus Events
 
@@ -536,13 +536,13 @@ Each of the following events is emitted— via Glean— at certain points while 
 
 Each message has a `message-key` extra.
 
-## Extending the system
+## Extending the System
 
 Much of the system relies on Nimbus [merging together JSON objects](/technical-reference/fml/growable-collections). We have seen this in the `messages` object which can contain messages from the default configuration, rollouts, and experiments.
 
 We can also add to the `actions`, `triggers` and `styles` object in the same way. This is covered below, and do not need an engineer.
 
-### Adding attributes
+### Adding Attributes
 
 Attributes require an application engineer to add values to the JSON object that is passed to the messaging subsystem.
 
@@ -551,7 +551,7 @@ Attributes require an application engineer to add values to the JSON object that
 
 Once in this JSON, this becomes available to JEXL expressions and string subsitution.
 
-### Adding custom trigger expressions
+### Adding Custom Trigger Expressions
 
 Trigger expressions can be added on a per-message basis, by adding to the `triggers` object.
 
@@ -600,7 +600,7 @@ Suitable tools to prototype these expressions:
  - [JEXL documentation](https://github.com/TomFrost/Jexl#all-the-details)
 
 
-### Adding custom actions
+### Adding Custom Actions
 
 All actions are implemented as URLs. Ad-hoc URLs can be used for one-off messages, but _must_ contain the scheme and separator: e.g. `https://`.
 
@@ -666,7 +666,7 @@ If the implementation stage has been done, but the FML part hasn't, you can add 
 
 Custom actions can be used in all messages only when they are added back to the application's [list of actions](#list-of-actions).
 
-## Lifecycle of a message
+## Lifecycle of a Message
 
 Like all Nimbus enabled features the messaging system configuration (messages, triggers, actions, styles) is likely to undergo a number of phases:
 
@@ -676,7 +676,7 @@ Like all Nimbus enabled features the messaging system configuration (messages, t
 
 ## Appendices
 
-### List of trigger expressions
+### List of Trigger Expressions
 
 These trigger expressions are based upon the default set of attrbutes available to Nimbus.
 
@@ -740,7 +740,7 @@ It is possible this table is out of date. The definitive source of truth for thi
 </Tabs>
 
 
-### List of actions
+### List of Actions
 
 These all correspond to the existing deeplinks in each app, so are entirely app specific.
 
@@ -799,7 +799,7 @@ Action                               | Description | Corresponding Deeplink |
 </TabItem>
 </Tabs>
 
-### List of attributes
+### List of Attributes
 
 By convention these are in `snake_case`.
 

--- a/docs/messaging/mobile-surveys.md
+++ b/docs/messaging/mobile-surveys.md
@@ -4,7 +4,9 @@ title: Surveys
 slug: /messaging/mobile-surveys
 ---
 
-# Mobile Survey Workflow
+Step-by-step workflow for creating, configuring, and launching mobile surveys via Nimbus.
+
+## Mobile Survey Workflow
 
 The required general steps to launch a mobile survey are:
 
@@ -18,14 +20,14 @@ The required general steps to launch a mobile survey are:
 
 Below, we'll elaborate on each step.
 
-## Create the survey
+## Create the Survey
 
 - Make sure the survey is configured to listen for URL parameters.
 - Get the survey link, perhaps something like `https://qsurvey.mozilla.com/s3/<survey_name>?app=android&userid={uuid}`
   - Note that some URL parameters are added to the end, make sure your survey provider supports these (Alchemer does).
   - Note also the special formatting around the `userid={uuid}` parameter, this is used to generate a unique identifier for each message click which allows survey responses to be linked to telemetry. See [the docs](/messaging/desktop/mobile-messaging#actions) for more info.
 
-## Invitation message copy
+## Invitation Message Copy
 
 The following copy elements are generally available for surveys:
 
@@ -35,7 +37,7 @@ The following copy elements are generally available for surveys:
 
 The full docs are [available here](/messaging/desktop/mobile-messaging#message-content)
 
-## Determine the audience
+## Determine the Audience
 
 Audience composition for surveys has two parts: the targeting criteria (who are eligible to be enrolled) and the sizing (what fraction of eligible clients will be invited)
 

--- a/docs/messaging/overview.md
+++ b/docs/messaging/overview.md
@@ -5,6 +5,8 @@ slug: /messaging/overview
 sidebar_position: 1
 ---
 
+How experiments interact with the messaging system, including surface-level exclusivity rules.
+
 Experiments enforce the rule that a user cannot enroll in multiple experiments of the same type (feature). Each messaging surface corresponds to a feature so we can only run a single experiment for any given messaging surface per cohort of users.
 
 There is no practical limitation of Messaging System for how many messages of the same type can exist. If deployed directly through Remote Settings multiple messages targeting the same surface can co-exist.


### PR DESCRIPTION
Because

* Some articles used H1 headings instead of H2 as top-level
* Headings were not consistently title-cased
* Summary paragraphs were missing from some articles

This commit

* Fixes heading nesting (`##` as top-level) in mobile-messaging and mobile-surveys
* Title-cases all headings across messaging articles
* Adds summary paragraphs to overview and mobile-surveys
* Removes orphaned `_category_.yml`
* Fixes typo in "String Substitutions" heading

fixes #748