### PR TITLE
chore: consistent formatting for advanced topics

### DIFF
--- a/docs/advanced/enrollment-state-machine.md
+++ b/docs/advanced/enrollment-state-machine.md
@@ -4,6 +4,8 @@ title: Enrollment State Machine
 slug: /advanced/enrollment-state-machine
 ---
 
+The possible enrollment states and transitions within the Nimbus SDK, including reasons for each state change.
+
 ## Possible States
 
 Within the Nimbus SDK there are multiple states, most of which have a "reason" associated with them.

--- a/docs/advanced/first-run-experiments.mdx
+++ b/docs/advanced/first-run-experiments.mdx
@@ -12,7 +12,7 @@ While the concept of First Run Experiments is also supported by Firefox for Desk
 
 :::
 
-## What is a First Run Experiment?
+## What Is a First Run Experiment?
 
 A First Run Experiment is one that needs to enroll clients on their first launch of the application. All First Run Experiments bundled with a particular app version would be evaluated for enrollment on the very first run of the application after it is installed.
 
@@ -87,7 +87,7 @@ Many use cases for First Run Experiments require advanced targeting configuratio
 
 Please follow the contributing guidelines when opening PRs to Experimenter. If you require assistance, please reach out in the #ask-experimenter channel on Slack.
 
-## How do I know if an experiment should be first run?
+## How Do I Know If an Experiment Should Be First Run?
 
 In short, if your experiment makes changes to onboarding, needs data from brand-new clients, or otherwise relates to clients who are using Firefox on their device for the first time, then your experiment should most likely be a First Run Experiment.
 

--- a/docs/advanced/notifications.mdx
+++ b/docs/advanced/notifications.mdx
@@ -10,7 +10,7 @@ Notifications exist on [Experimenter](https://experimenter.services.mozilla.com/
 
 These notifications do not necessitate action on the owners' part, but are a reminder to check the enrollment numbers and live monitoring to see if actions can be taken at the proposed dates.
 
-### Non-owner subscribers
+## Non-Owner Subscribers
 
 Non-owners can now subscribe to the same notification emails that experiment owners receive. 
 

--- a/docs/advanced/warnings.mdx
+++ b/docs/advanced/warnings.mdx
@@ -6,7 +6,7 @@ slug: /advanced/warnings
 
 There are a number of warning messages that you may encounter on Experimenter in the course of launching your experiment. These warnings are listed below, along with any restrictions that they may impose on an experiment.
 
-## Rollout bucketing warning
+## Rollout Bucketing Warning
 
 :::tip
 See the [Rollout FAQ](/advanced/rollouts) for general rollout information
@@ -31,7 +31,7 @@ To prevent this situation, check the "Prevent enrollment if users have changed a
 <img style={{border:"1px solid grey"}} title="SetPrefs prevent enrollment" src="/img/faq/setpref-prevent-enrollment.png" align="center"/>
 
 
-## Audience overlap
+## Audience Overlap
 
 There are cases where the audience of two experiments/rollouts will overlap in ways that Experimenter can predict. Audience overlap will generally result in under enrollment which can potentially invalidate an experiment. There are three scenarios where we can detectable cases of audience overlap so that experiment owners can adjust their [sizing][2] accordingly.
 
@@ -39,17 +39,17 @@ The warnings list the `slugs` of the experiments that overlap with yours (the `s
 
 These warnings do not prevent experiments from being launched.
 
-#### Live experiments exist on a previous iteration of a namespace
+### Live Experiments Exist on a Previous Iteration of a Namespace
 
 <img style={{border:"1px solid grey"}} title="Live experiments in namespace warning" src="/img/faq/prev-namespace-warning.png" align="center"/>
 <p/>
 
-#### Live multi-feature experiments exist on this feature
+### Live Multi-Feature Experiments Exist on This Feature
 
 <img style={{border:"1px solid grey"}} title="Live multfeature experiments warning" src="/img/faq/multifeature-warning.png" align="center"/>
 <p/>
 
-#### An experiment excludes other live deliveries
+### An Experiment Excludes Other Live Deliveries
 
 <img style={{border:"1px solid grey"}} title="Excludes live deliveries warning" src="/img/faq/excluded-warning.png" align="center"/>
 


### PR DESCRIPTION
Because

* Headings were not consistently title-cased
* Some articles used H3/H4 where H2/H3 was appropriate
* Summary paragraph was missing from enrollment state machine article

This commit

* Title-cases all headings across 4 advanced topic articles
* Bumps heading levels in notifications and warnings articles
* Adds summary paragraph to enrollment state machine

fixes #749