### PR TITLE
chore: consistent formatting for technical reference, resources, and external links

### DIFF
--- a/docs/resources/foxfooding.md
+++ b/docs/resources/foxfooding.md
@@ -4,14 +4,16 @@ title: Foxfooding
 slug: /resources/foxfooding
 ---
 
-# Feature team setting up a Foxfood
+How to set up and participate in foxfooding using Nimbus rollouts and Dev Tools.
+
+## Feature Team Setting Up a Foxfood
 
 Create a rollout with the change you want Mozillians to be able to try. 
 Set the Audience size to the lowest it will accept - or .0001 with 1 expected client.  We aren't going to actually launch this - but lowest is always safest.
 Click "Preview for Testing" - and it's ready!
 
 
-# Foxfooding with Nimbus Dev Tools
+## Foxfooding with Nimbus Dev Tools
 
 Start by installing Nimbus Dev Tools.  If you aren't a developer, don't let the "Dev Tools" or add-on scare you away. This is easy!
 
@@ -23,11 +25,11 @@ Start by installing Nimbus Dev Tools.  If you aren't a developer, don't let the 
 6. click "actions" and select "force enroll"
 - You can verify in about:studies (you may need to refresh page) and you will be enrolled to foxfood.
 
-# If you have problems installing Nimbus Dev Tools...
+## If You Have Problems Installing Nimbus Dev Tools...
 - Here is a [65 second video on how to install Nimbus dev tools](https://mozilla.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=b7b2d02b-79ba-43a0-a708-b2a60107f0bf). Watching the video takes half the time to getting Nimbus Dev Tools installed. 
 - Here is the [link to docs on how to install Nimbus Dev Tools](https://experimenter.info/nimbus-devtools-guide#installation). 
 
-## If you have questions how to use Nimbus Dev Tools...
+## If You Have Questions How to Use Nimbus Dev Tools...
 
 Here is a 90 second video on [how to force enroll into a foxfooding experiment](https://mozilla.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=91da9998-b2e8-4314-aa83-b330014e2441).
 

--- a/docs/resources/local-enrollment.md
+++ b/docs/resources/local-enrollment.md
@@ -4,6 +4,8 @@ title: Local Enrollment
 slug: /resources/local-enrollment
 ---
 
+How to set up a local development environment for testing Nimbus experiments on Desktop and Mobile.
+
 ## Desktop
 Preferences to set in Firefox
 - `nimbus.debug`: `True`

--- a/docs/resources/nimbus-devtools-guide.md
+++ b/docs/resources/nimbus-devtools-guide.md
@@ -4,11 +4,11 @@ title: Developer Tools
 slug: /resources/nimbus-devtools-guide
 ---
 
-# Nimbus Developer Tools Guide
+## Nimbus Developer Tools Guide
 
 This guide provides an overview of the Nimbus Developer Tools, designed for Nimbus experiment debugging. With these tools, you can more easily test experiments, debug targeting expressions, and browse through available experiments.
 
-### Installation
+## Installation
 
 To install the Nimbus Developer Tools, download the latest release from the [Nimbus DevTools GitHub repository](https://github.com/mozilla-extensions/nimbus-devtools/releases).
 

--- a/docs/technical-reference/fml/_category_.yml
+++ b/docs/technical-reference/fml/_category_.yml
@@ -1,4 +1,0 @@
-position: 2
-label: "Feature Manifest Language"
-collapsible: true
-collapsed: true

--- a/docs/technical-reference/integration-tests.md
+++ b/docs/technical-reference/integration-tests.md
@@ -4,7 +4,7 @@ title: Integration Tests
 slug: /technical-reference/integration-tests
 ---
 
-# Integration Tests
+How to run the end-to-end Selenium integration test suite for Nimbus.
 
 ## About
 
@@ -12,6 +12,7 @@ The integration test suite is an end-to-end test suite that uses Selenium and Fi
 
 ## Nimbus Tests
 ### Getting Started
+
 
 You must have Docker installed.
 

--- a/docs/technical-reference/system-architecture.mdx
+++ b/docs/technical-reference/system-architecture.mdx
@@ -1,9 +1,12 @@
 ---
 id: system-architecture
+title: System Architecture
 slug: /technical-reference/system-architecture
 ---
 
-# System architecture / components
+An overview of the Nimbus system components, from experiment configuration through client-side SDK to analysis.
+
+## System Architecture / Components
 <img style={{border:"1px solid grey"}} title="Nimbus system architecture" src="/img/faq/nimbus-system-architecture.png"/>
 [original lives here](https://miro.com/app/board/uXjVOkkueZY=/)
 
@@ -18,7 +21,7 @@ This is the interface to start, end enrollment, end, and look at results.
 This is a shared service at Mozilla - that is used to remotely configure the clients. 
 This is the means of applying experiment changes to the client off-train.
 
-## Client Side
+## Client-Side
 
 ### SDK
 Each of the Firefox platforms has an SDK that handles all the experiment operations of targeting, enrolling, bucketing, etc.  
@@ -34,8 +37,8 @@ This and the client telemetry use the applications existing Glean or Legacy Tele
 Jetstream runs nightly to automatically analyze the metrics for experiments.  
 It runs some metrics for every experiment (varies by platform) and can run additional metrics if there are custom configuration files applied to the experiment.
 
-### Custom Configuration (AKA Jetstream Configuration Files)  
+### Custom Configuration (AKA Jetstream Configuration Files)
 A data scientist can write a custom configuration file named after the slug of the experiment to add metrics to an experiment.
 
-### Analysis library (MozAnalysis)
+### Analysis Library (MozAnalysis)
 Only interfaced with through the data team - this is a repository of vetted metric formulas that can be applied when needed by Data Scientists.


### PR DESCRIPTION
Because

* Some articles used H1 headings instead of H2 as top-level
* Summary paragraphs were missing from several articles
* Headings were not consistently title-cased

This commit

* Fixes heading nesting and title-cases headings across 5 articles
* Adds summary paragraphs to 5 articles missing them
* Removes orphaned FML `_category_.yml`
* Adds title to system-architecture frontmatter

fixes #750
fixes #752
fixes #753